### PR TITLE
Issue 2: Implement the API health check

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,13 +7,21 @@ type UiState = "idle" | "loading" | "success" | "error";
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
+  const [error, setError] = useState("");
+  // Categories are stored now but not rendered until Issue 4.
   void categories;
 
   async function handleCheck() {
-    // TODO(Issue 4): set loading, call checkSystem(), then either
-    //   - success: store categories and show Online + the list, or
-    //   - error: show Offline + a useful message.
     setState("loading");
+    setError("");
+    try {
+      const status = await checkSystem();
+      setCategories(status.categories);
+      setState("success");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not reach the API.");
+      setState("error");
+    }
   }
 
   return (
@@ -26,7 +34,19 @@ export default function App() {
         {state === "loading" ? "Loading…" : "Check System"}
       </button>
 
-      {/* TODO(Issue 4): render loading / success (Online + categories) / error (Offline) states. */}
+      {state === "success" && (
+        <p className="mt-3 mb-0">
+          Status: <span className="text-success fw-semibold">Online</span>
+        </p>
+      )}
+
+      {state === "error" && (
+        <p className="mt-3 mb-0">
+          Status: <span className="text-danger fw-semibold">Offline</span> — {error}
+        </p>
+      )}
+
+      {/* TODO(Issue 4): render the category list under the Online status. */}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -11,11 +11,16 @@ export interface SystemStatus {
 }
 
 // Issue 2 + Issue 4 — call the backend.
-// Steps: fetch `${API_URL}/api/health`; if not ok, throw.
-//        then fetch `${API_URL}/api/categories`; if not ok, throw.
-//        return { online: true, categories }.
-// Throwing on failure lets the UI show a single Offline/error state.
+// Throwing on failure lets the UI show a single Offline/error state. A server
+// that is down makes fetch() reject on its own, so that path needs no handling
+// here — it surfaces as the same Offline state.
 export async function checkSystem(): Promise<SystemStatus> {
-  // TODO(Issue 2 & 4): implement the two fetch calls described above.
-  throw new Error("checkSystem not implemented yet");
+  const health = await fetch(`${API_URL}/api/health`);
+  if (!health.ok) {
+    throw new Error(`Health check failed (HTTP ${health.status}).`);
+  }
+
+  // TODO(Issue 4): fetch `${API_URL}/api/categories`, throw if not ok, and
+  // return the real list here instead of the empty one.
+  return { online: true, categories: [] };
 }

--- a/docs/lab-01/reviewer.md
+++ b/docs/lab-01/reviewer.md
@@ -6,8 +6,8 @@
 ## Pull Requests I authored (reviewed by my partner)
 | PR | Branch | Reviewer verdict |
 |----|--------|------------------|
-| [#5](https://github.com/Nuggetkub/toktickit/pull/5) | feature/1-project-foundation | pending |
-|    | feature/2-health-check |  |
+| [#5](https://github.com/Nuggetkub/toktickit/pull/5) | feature/1-project-foundation | approved by @Earth2509, merged 2026-08-08 |
+| [#6](https://github.com/Nuggetkub/toktickit/pull/6) | feature/2-health-check | pending |
 |    | feature/3-category-seed |  |
 |    | feature/4-category-list |  |
 

--- a/docs/lab-01/tests.md
+++ b/docs/lab-01/tests.md
@@ -4,10 +4,41 @@ All test files live under server/tests/lab-01/ and client/tests/lab-01/.
 
 | # | Tool | Test | Result |
 |---|------|------|--------|
-| 1 | Supertest | GET /api/health returns 200, status=ok | red — stub returns 501 until Issue 2 |
+| 1 | Supertest | GET /api/health returns 200, status=ok | pass (Issue 2) |
 | 2 | Supertest | GET /api/categories returns 4 seeded categories in id order | todo — Issue 4 |
 | 3 | Vitest | Heading renders | pass |
-| 4 | Vitest | Success state shows Online + category list | |
-| 5 | Vitest | Error state shows Offline + message | |
+| 4 | Vitest | Success state shows Online + category list | todo — Issue 4 |
+| 5 | Vitest | Error state shows Offline + message | todo — Issue 4 |
 
 Paste your passing terminal output / screenshot below.
+
+## Issue 2 — `GET /api/health`
+
+Server (`cd server && npm test`):
+
+```
+ ↓ tests/lab-01/categories.test.ts (1 test | 1 skipped)
+ ✓ tests/lab-01/health.test.ts (1 test) 20ms
+
+ Test Files  1 passed | 1 skipped (2)
+      Tests  1 passed | 1 todo (2)
+```
+
+Client (`cd client && npm test`):
+
+```
+ ✓ tests/lab-01/App.test.tsx (3 tests | 2 skipped) 19ms
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 2 todo (3)
+```
+
+Live check against the running API (`curl -i http://localhost:3000/api/health`):
+
+```
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+Content-Type: application/json; charset=utf-8
+
+{"status":"ok","service":"TokTickIT API"}
+```

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,8 +18,7 @@ app.use(express.json());
 // It must return HTTP 200 with JSON: { status: "ok", service: "TokTickIT API" }
 // ---------------------------------------------------------------------------
 app.get("/api/health", (_req: Request, res: Response) => {
-  // TODO(Issue 2): replace this stub with the required 200 response.
-  res.status(501).json({ error: "Not implemented yet" });
+  res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2.

## Server
`GET /api/health` now returns `200 { "status": "ok", "service": "TokTickIT API" }`,
replacing the 501 stub. `tests/lab-01/health.test.ts` goes from red to green with
no change to the test itself.

## Client
`checkSystem()` fetches `/api/health` and throws on a non-ok status. The existing
`[Check System]` button is now wired to it and renders the outcome:

- **success** → `Status: Online`
- **error** → `Status: Offline — <message>`

Both a rejected `fetch` (server not running) and a non-ok response land in the same
Offline branch, so there is one failure path for the UI rather than two.

## Test evidence
```
server:  1 passed | 1 todo   (health green; categories still todo)
client:  1 passed | 2 todo
tsc --noEmit: clean
```

Live against the running API:
```
$ curl -i http://localhost:3000/api/health
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
{"status":"ok","service":"TokTickIT API"}
```

## Deliberately left for #4
- The `/api/categories` fetch inside `checkSystem()` (returns an empty list for now).
- Rendering the category list under the Online status.
- The two `it.todo` cases in `App.test.tsx` — the scaffold assigns those to #4, so I
  left the slots free rather than writing tests that #4 would immediately rewrite. I
  did verify the Online / Offline / non-ok-status branches locally before removing
  the scratch test.
