### PR TITLE
Issue 4: Display the IT request category list

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,8 +8,6 @@ export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
   const [error, setError] = useState("");
-  // Categories are stored now but not rendered until Issue 4.
-  void categories;
 
   async function handleCheck() {
     setState("loading");
@@ -34,10 +32,29 @@ export default function App() {
         {state === "loading" ? "Loading…" : "Check System"}
       </button>
 
+      {state === "loading" && (
+        <p className="mt-3 mb-0 text-secondary">Checking the API…</p>
+      )}
+
       {state === "success" && (
-        <p className="mt-3 mb-0">
-          Status: <span className="text-success fw-semibold">Online</span>
-        </p>
+        <>
+          <p className="mt-3 mb-2">
+            Status: <span className="text-success fw-semibold">Online</span>
+          </p>
+
+          <h2 className="h6 mt-4">Request categories</h2>
+          {categories.length === 0 ? (
+            <p className="text-secondary mb-0">No categories found.</p>
+          ) : (
+            <ul className="list-group">
+              {categories.map((category) => (
+                <li key={category.id} className="list-group-item">
+                  {category.name}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
 
       {state === "error" && (
@@ -45,8 +62,6 @@ export default function App() {
           Status: <span className="text-danger fw-semibold">Offline</span> — {error}
         </p>
       )}
-
-      {/* TODO(Issue 4): render the category list under the Online status. */}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -20,7 +20,11 @@ export async function checkSystem(): Promise<SystemStatus> {
     throw new Error(`Health check failed (HTTP ${health.status}).`);
   }
 
-  // TODO(Issue 4): fetch `${API_URL}/api/categories`, throw if not ok, and
-  // return the real list here instead of the empty one.
-  return { online: true, categories: [] };
+  const response = await fetch(`${API_URL}/api/categories`);
+  if (!response.ok) {
+    throw new Error(`Could not load categories (HTTP ${response.status}).`);
+  }
+
+  const categories = (await response.json()) as Category[];
+  return { online: true, categories };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+afterEach(() => vi.restoreAllMocks());
 
 describe("App", () => {
   // WORKED EXAMPLE — provided for you.
@@ -9,9 +13,42 @@ describe("App", () => {
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
-  // Issue 4 — write these yourself. Hint: mock the api module with
-  // vi.spyOn(api, "checkSystem").mockResolvedValue(...) / .mockRejectedValue(...)
-  // then click the button and assert the Online list / Offline message.
-  it.todo("shows Online and the seeded categories on success");
-  it.todo("shows an Offline error message when the API is unavailable");
+  it("shows Online and the seeded categories on success", async () => {
+    vi.spyOn(api, "checkSystem").mockResolvedValue({
+      online: true,
+      categories: [
+        { id: 1, name: "Account and Access" },
+        { id: 2, name: "Hardware" },
+        { id: 3, name: "Software" },
+        { id: 4, name: "Network" },
+      ],
+    });
+
+    render(<App />);
+    await userEvent.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText("Online")).toBeInTheDocument();
+
+    const items = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(items).toEqual([
+      "Account and Access",
+      "Hardware",
+      "Software",
+      "Network",
+    ]);
+  });
+
+  it("shows an Offline error message when the API is unavailable", async () => {
+    vi.spyOn(api, "checkSystem").mockRejectedValue(
+      new Error("Failed to fetch"),
+    );
+
+    render(<App />);
+    await userEvent.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText("Offline")).toBeInTheDocument();
+    expect(screen.getByText(/Failed to fetch/i)).toBeInTheDocument();
+    // The category list must not render in the error state.
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+  });
 });

--- a/docs/lab-01/tests.md
+++ b/docs/lab-01/tests.md
@@ -5,10 +5,14 @@ All test files live under server/tests/lab-01/ and client/tests/lab-01/.
 | # | Tool | Test | Result |
 |---|------|------|--------|
 | 1 | Supertest | GET /api/health returns 200, status=ok | pass (Issue 2) |
-| 2 | Supertest | GET /api/categories returns 4 seeded categories in id order | todo — Issue 4 |
+| 2 | Supertest | GET /api/categories returns 4 seeded categories in id order | pass (Issue 4) |
 | 3 | Vitest | Heading renders | pass |
-| 4 | Vitest | Success state shows Online + category list | todo — Issue 4 |
-| 5 | Vitest | Error state shows Offline + message | todo — Issue 4 |
+| 4 | Vitest | Success state shows Online + category list | pass (Issue 4) |
+| 5 | Vitest | Error state shows Offline + message | pass (Issue 4) |
+
+Two extra tests were added beyond the five planned: a server test that ids are
+ascending and the payload exposes only `{ id, name }`, and an assertion that the
+category list does not render in the Offline state.
 
 Paste your passing terminal output / screenshot below.
 
@@ -81,3 +85,50 @@ toktickit=# SELECT id, name FROM "Category" ORDER BY id;
   4 | Network
 (4 rows)
 ```
+
+## Issue 4 — Category list (full suite green)
+
+Server (`cd server && npm test`):
+
+```
+ ✓ tests/lab-01/health.test.ts (1 test) 16ms
+ ✓ tests/lab-01/categories.test.ts (2 tests) 55ms
+
+ Test Files  2 passed (2)
+      Tests  3 passed (3)
+```
+
+Client (`cd client && npm test`):
+
+```
+ ✓ tests/lab-01/App.test.tsx (3 tests) 160ms
+
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+```
+
+**6 tests, 0 failures, 0 todo.** `tsc --noEmit` clean on the client.
+
+Live endpoint:
+
+```
+$ curl http://localhost:3000/api/categories
+[{"id":1,"name":"Account and Access"},{"id":2,"name":"Hardware"},
+ {"id":3,"name":"Software"},{"id":4,"name":"Network"}]
+```
+
+### Failure path verified for real
+
+The 500 branch was exercised by stopping the Postgres container rather than by
+mocking, to confirm no internal details leak:
+
+```
+$ docker stop toktickit-db
+$ curl -i http://localhost:3000/api/categories
+HTTP/1.1 500 Internal Server Error
+{"error":"Could not load categories."}
+```
+
+The full `PrismaClientKnownRequestError` was written to the server log only. Note
+that `/api/health` still returned 200 with the database down — the lazy Prisma
+singleton means the health route never opens a connection.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,6 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
-// getPrisma() is your lazy database handle. Call it INSIDE a route when you
-// need the DB (Issue 4). It is intentionally unused until then.
-void getPrisma;
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -21,13 +18,18 @@ app.get("/api/health", (_req: Request, res: Response) => {
   res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
-// ---------------------------------------------------------------------------
-// Issue 4 — Category list
-// Add:  GET /api/categories
-//   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
-//   -> return each { id, name } in a predictable (id) order
-//   -> on failure, respond 500 with a safe message (no internal details)
-// TODO(Issue 4): implement the route here.
-// ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      select: { id: true, name: true },
+      orderBy: { id: "asc" },
+    });
+    res.status(200).json(categories);
+  } catch (err) {
+    // Log the real cause for us, but never leak it to the client.
+    console.error("GET /api/categories failed:", err);
+    res.status(500).json({ error: "Could not load categories." });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,15 +1,28 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
-void request; void app;
 
-// Issue 4 — write this test yourself, using health.test.ts as the pattern.
-// Requires the DB to be migrated and seeded first.
-// It should assert: GET /api/categories returns 200 and the four seeded
-// category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
-    // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+// Requires the DB to be migrated and seeded first:
+//   npx prisma migrate dev  &&  npm run prisma:seed
+const SEEDED_NAMES = ["Account and Access", "Hardware", "Software", "Network"];
+
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(4);
+    expect(res.body.map((c: { name: string }) => c.name)).toEqual(SEEDED_NAMES);
+  });
+
+  it("returns ids in ascending order and exposes only id and name", async () => {
+    const res = await request(app).get("/api/categories");
+
+    const ids = res.body.map((c: { id: number }) => c.id);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+    // createdAt is an internal detail — the API contract is { id, name }.
+    for (const category of res.body) {
+      expect(Object.keys(category).sort()).toEqual(["id", "name"]);
+    }
   });
 });


### PR DESCRIPTION
Closes #4. Final feature issue — the vertical slice is complete after this.

## Server — `GET /api/categories`
```ts
const categories = await getPrisma().category.findMany({
  select: { id: true, name: true },
  orderBy: { id: "asc" },
});
```
`select` is deliberate: `createdAt` exists on the model but is an internal detail,
so the API contract stays `{ id, name }`. On failure the real error is logged
server-side and the client gets a generic `500 { error: "Could not load categories." }`.

## Client
`checkSystem()` now chains health → categories. Either step failing throws, so the
UI keeps a single Offline path. `App.tsx` renders all four states: idle, loading,
success (Online + list), error (Offline + message).

## Tests — 6 passing, 0 todo
```
server:  health 1 + categories 2  =  3 passed
client:  heading + success + error =  3 passed
tsc --noEmit: clean
```
Beyond the five planned tests I added two: ids are ascending and the payload
exposes only `{ id, name }`; and the category list must *not* render in the error
state.

## The 500 path was verified for real, not mocked
```
$ docker stop toktickit-db
$ curl -i http://localhost:3000/api/categories
HTTP/1.1 500 Internal Server Error
{"error":"Could not load categories."}
```
The full `PrismaClientKnownRequestError` went to the server log only. Worth noting
`/api/health` still returned **200** with the database down — the lazy Prisma
singleton means the health route never opens a connection. That is the intended
behaviour, but it does mean "healthy" says nothing about the database.

## @Earth2509 — specific things worth your review
1. **Should `/api/health` check the database?** Right now it can report healthy
   while Postgres is down (proven above). Arguably fine for a liveness probe, but
   it is a real design choice worth a second opinion.
2. **Ordering by `id` rather than `name`.** It depends on seed insertion order, so
   a reseeded database in a different order would change the API response. Is
   `orderBy: { name: "asc" }` the more honest contract?
3. **The client tests mock `checkSystem` entirely**, so the fetch chain in `api.ts`
   is not directly covered. Worth mocking at the `fetch` level instead?
