### PR TITLE
Docs: write the README and align tests.md / ai_use.md with the required schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,142 @@
-# TokTickIT 
+# TokTickIT
+
+An IT service desk ticketing system. This repository contains the Lab 1 vertical
+slice: a React client that asks a Node/Express API whether the system is online and
+which request categories are available, with the categories served from PostgreSQL
+through Prisma.
+
+## Stack
+
+| Layer | Technology |
+|---|---|
+| Client | React 18, Vite 6, TypeScript 5.7, Bootstrap 5.3 |
+| Server | Node, Express 4.21, TypeScript 5.7 |
+| Database | PostgreSQL 17 |
+| ORM | Prisma 5.22 |
+| Tests | Vitest 2.1 (both sides), Supertest 7 (API) |
+
+## Prerequisites
+
+- Node.js 20 or newer
+- Docker (for PostgreSQL)
+
+## Setup
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/Nuggetkub/toktickit.git
+cd toktickit
+npm install --prefix server
+npm install --prefix client
+```
+
+### 2. Start PostgreSQL
+
+```bash
+docker run -d --name toktickit-db \
+  -e POSTGRES_USER=toktickit \
+  -e POSTGRES_PASSWORD=toktickit \
+  -e POSTGRES_DB=toktickit \
+  -p 5433:5432 postgres:17
+
+docker exec toktickit-db pg_isready -U toktickit   # expect "accepting connections"
+```
+
+The container publishes **5433** on the host, not the default 5432, so it will not
+collide with a PostgreSQL you may already be running. If the container already
+exists, start it with `docker start toktickit-db` instead of `docker run`.
+
+### 3. Create the environment files
+
+```bash
+cp server/.env.example server/.env
+cp client/.env.example client/.env
+```
+
+The defaults match the container above, so no editing is needed for local
+development. Real `.env` files are git-ignored and must never be committed.
+
+| Variable | File | Default |
+|---|---|---|
+| `DATABASE_URL` | `server/.env` | `postgresql://toktickit:toktickit@localhost:5433/toktickit?schema=public` |
+| `PORT` | `server/.env` | `3000` |
+| `VITE_API_URL` | `client/.env` | `http://localhost:3000` |
+
+### 4. Migrate and seed the database
+
+```bash
+cd server
+npx prisma migrate deploy   # use `npx prisma migrate dev` when changing the schema
+npm run prisma:seed
+```
+
+The seed is idempotent — it upserts on the unique category name, so running it
+repeatedly will not create duplicates. It inserts four categories: Account and
+Access, Hardware, Software, Network.
+
+### 5. Run the app
+
+Two terminals:
+
+```bash
+cd server && npm run dev    # http://localhost:3000
+```
+
+```bash
+cd client && npm run dev    # http://localhost:5173
+```
+
+Open http://localhost:5173 and click **[Check System]**. On success the page shows
+the system status as online followed by the four categories; if the API cannot be
+reached it shows the offline status and an error message.
+
+## Tests
+
+```bash
+cd server && npm test    # Vitest + Supertest — API-01, API-02
+cd client && npm test    # Vitest + Testing Library — UI-01, UI-02, UI-03
+```
+
+Six tests in total. See [`docs/lab-01/tests.md`](docs/lab-01/tests.md) for the test
+plan and recorded evidence.
+
+## API
+
+| Method | Path | Success | Failure |
+|---|---|---|---|
+| GET | `/api/health` | `200 { "status": "ok", "service": "TokTickIT API" }` | — |
+| GET | `/api/categories` | `200 [{ "id": 1, "name": "Account and Access" }, …]` | `500 { "error": "Could not load categories." }` |
+
+`/api/health` deliberately does not touch the database, so it answers even when
+PostgreSQL is down. On a database failure `/api/categories` logs the underlying
+error server-side and returns a generic message, so no internal detail is exposed.
+
+## Repository layout
+
+```text
+client/
+  src/            React app (App.tsx, api.ts)
+  tests/lab-01/   UI tests
+server/
+  src/            Express app (app.ts, index.ts, prisma.ts)
+  prisma/         schema, migrations, seed
+  tests/lab-01/   API tests
+docs/lab-01/      tests.md, reviewer.md, ai_use.md
+```
+
+## Branching model
+
+`feature/*` → `lab1-staging` → `main`. Both `lab1-staging` and `main` are protected:
+one approval is required and direct pushes are blocked, so every change arrives by
+reviewed pull request.
+
+## Troubleshooting
+
+**`P1000: Authentication failed`** — usually the wrong port rather than bad
+credentials. If another PostgreSQL is listening on 5432, a `DATABASE_URL` pointing
+there will reach the wrong server and fail authentication. Confirm the URL uses
+**5433**.
+
+**The API dies with no error in the log** — an orphaned `tsx watch` process may be
+competing for port 3000. Check with `netstat -ano | findstr :3000` and stop strays.

--- a/docs/lab-01/ai_use.md
+++ b/docs/lab-01/ai_use.md
@@ -1,24 +1,59 @@
 # Lab 1 — AI Use and Reflection
 
-**LLM/agent used:** Claude Code (Anthropic Claude Opus 4.8), with the NotebookLM
-skill for reading the lab sources.
+## AI coding agent used
 
-## Selected key prompts (6–10)
-| # | Prompt (summarised) | What I did with the result |
-|---|---------------------|----------------------------|
-| 1 | "Discuss Lab 1 with NotebookLM" — summarise the labsheet, glossary and Git cheat-sheet | Got an overview of the vertical-slice goal, the 4 mandatory issues, and the Git Flow / Kanban / PR-review rules. Used it to plan the whole sprint. |
-| 2 | "The TA gave me a `Lab1_Starter_Scaffold` folder — is this the main project, and do I create the repository first?" | Confirmed the `toktickit/` scaffold is the project skeleton (with `TODO(Issue N)` markers) and that the repo must be created first. Noted the labsheet expects building the foundation myself, so I flagged it to confirm with the TA. |
-| 3 | "Write the exact git commands to set up the repo — TA said make it public" | Got the `git init` -> commit -> `gh repo create toktickit --public` -> `lab1-staging` command sequence and ran it. |
-| 4 | "Check `.gitignore` before I commit" | Verified via a dry-run that no `.env`, `node_modules/`, or `*.db` files would be committed (only `.env.example` templates) before the first commit. |
-| 5 | "Help me set up GitHub (issues, branch protection, board, reviewer)" | Created the 4 issues, applied branch protection (1 approval, no direct push) to `main` and `lab1-staging`, invited the peer reviewer, and built the "TokTickIT Individual Sprints" board with the 6 required columns. |
-| 6 | "Walk me through Issue 1" | Installed client/server deps, created `.env` files, ran `prisma generate`, ran the test suites, and set up a Postgres 17 Docker container on port 5433. |
+**Claude Code** (Anthropic), driven from the terminal, together with **NotebookLM**
+for reading the lab sources (labsheet, glossary, Git cheat-sheet).
+
+> `[VERIFY BEFORE SUBMITTING: confirm the exact model name. An earlier draft of this`
+> `file recorded "Claude Opus 4.8".]`
+
+## Selected key prompts
+
+> `[EDIT BEFORE SUBMITTING: the reflection column is drawn from the real session`
+> `history — rewrite it in your own voice.]`
+
+| Prompt Name | Actual Prompt Text | My Reflection |
+|---|---|---|
+| Plan Lab 1 implementation | "Discuss Lab 1 with NotebookLM — summarise the labsheet, glossary and Git cheat-sheet." | Gave me the vertical-slice goal, the four mandatory issues and the Git Flow / Kanban / PR-review rules before writing any code, so I could plan the whole sprint instead of discovering requirements halfway through. |
+| Clarify the starter scaffold | "The TA gave me a `Lab1_Starter_Scaffold` folder — is this the main project, and do I create the repository first?" | Confirmed the scaffold is the skeleton with `TODO(Issue N)` markers and that the repo comes first. It also surfaced a conflict with the labsheet, which says to build the foundation yourself. I raised it with my reviewer rather than deciding alone. |
+| Set up the repository | "Write the exact git commands to set up the repo — TA said make it public." | Naming the constraint ("public") produced an exact, runnable command sequence instead of generic advice. This was the clearest lesson of the lab: concrete constraints beat descriptions. |
+| Guard the secrets | "Check `.gitignore` before I commit." | A dry run confirmed no `.env`, `node_modules/` or `*.db` would be committed, only the `.env.example` templates. Cheap to ask and expensive to get wrong, so I asked before the first commit rather than after. |
+| Set up the GitHub process | "Help me set up GitHub — issues, branch protection, board, reviewer." | Created the four issues, applied branch protection to `main` and `lab1-staging`, invited the peer reviewer and built the board with the six required columns in one pass. |
+| Implement each issue | "Start Issue N." | Worked well precisely because each issue had explicit acceptance criteria. The agent kept scope to that issue and left `TODO(Issue N)` markers for the rest instead of running ahead. |
+| Verify the failure path | (agent's own choice) stop the database container instead of mocking the error | I would have mocked it. Stopping the real container proved the 500 response was safe and revealed something I had not considered: `/api/health` still returns 200 with the database down, because the lazy Prisma client never opens a connection. |
+| Draft the report | "Draft one PDF file with NotebookLM." | NotebookLM produced the correct rubric structure but replaced every piece of terminal evidence with placeholders and invented an AI-agent identity. See the reflection below — this was the most useful failure of the lab. |
 
 ## Reflection
-My prompts got better when I gave the agent concrete constraints (e.g. "public
-repo", "check .gitignore first") instead of vague requests — that produced exact,
-runnable commands rather than generic advice. The main thing I had to correct was
-the assumption about starter code: the agent initially treated the scaffold as
-Issue 1, but the labsheet says the foundation should be built from scratch, so I
-noted this to verify with my TA before submitting. I also learned to expect the
-health-check test to stay red until Issue 2 (test-driven), rather than treating it
-as a broken setup.
+
+My prompts improved when I supplied concrete constraints rather than descriptions.
+"Make the repo public", "check `.gitignore` first", "start Issue 3" produced exact
+commands and correctly scoped changes, whereas open-ended requests produced generic
+advice I then had to narrow anyway.
+
+Three things had to be corrected, and they were the most instructive part of the lab.
+
+First, the agent initially treated the TA's pre-wired scaffold as satisfying Issue 1,
+while the labsheet says to build the foundation yourself. I flagged the conflict
+instead of accepting the convenient reading, and raised it in peer review.
+
+Second, I had to learn to read a failing test correctly. The health-check test stays
+red until Issue 2 by design — that is test-driven development working as intended,
+not a broken environment. Treating red as "something is wrong" would have sent me
+debugging a correct setup.
+
+Third, and most importantly, when I asked NotebookLM to generate this report it
+**fabricated the AI-use section**, stating the work had been done with "Antigravity
+powered by Gemini 3.5 Flash" with invented prompts and reflections. That text came
+from an example in the labsheet, not from my project. It also replaced every code
+block of real evidence with `[DATA MISSING IN SOURCE]` markers even though the data
+was present in the source document I had supplied, and returned the whole report in
+Thai after being asked for English. Submitting that output unread would have meant
+submitting false statements about my own work.
+
+The lesson I take from the lab is that generated output has to be checked against the
+artefacts it claims to describe, and that confident formatting is not evidence of
+accuracy. The same scepticism applies to peer review: my reviewer's advice on the
+`.gitignore` negation rule reached the right conclusion through incorrect reasoning,
+which I only found by actually testing the pattern in a scratch repository rather
+than accepting it.

--- a/docs/lab-01/tests.md
+++ b/docs/lab-01/tests.md
@@ -1,55 +1,47 @@
-# Lab 1 — Test Plan and Evidence  (fill this in)
+# Lab 1 — Test Plan and Evidence
 
-All test files live under server/tests/lab-01/ and client/tests/lab-01/.
+All test files live under `server/tests/lab-01/` and `client/tests/lab-01/`.
 
-| # | Tool | Test | Result |
-|---|------|------|--------|
-| 1 | Supertest | GET /api/health returns 200, status=ok | pass (Issue 2) |
-| 2 | Supertest | GET /api/categories returns 4 seeded categories in id order | pass (Issue 4) |
-| 3 | Vitest | Heading renders | pass |
-| 4 | Vitest | Success state shows Online + category list | pass (Issue 4) |
-| 5 | Vitest | Error state shows Offline + message | pass (Issue 4) |
+## Test specification
 
-Two extra tests were added beyond the five planned: a server test that ids are
-ascending and the payload exposes only `{ id, name }`, and an assertion that the
-category list does not render in the Offline state.
+| Test ID | Test File Path | Tool | Test Description |
+|---|---|---|---|
+| API-01 | `server/tests/lab-01/health.test.ts` | Supertest | `GET /api/health` returns HTTP 200 with the JSON body `{ status: "ok", service: "TokTickIT API" }`. |
+| API-02 | `server/tests/lab-01/categories.test.ts` | Supertest | `GET /api/categories` returns the four seeded categories in id order. A second case asserts the ids ascend and each object exposes only `{ id, name }`. |
+| UI-01 | `client/tests/lab-01/App.test.tsx` | Vitest | The "TokTickIT" heading renders on the page. |
+| UI-02 | `client/tests/lab-01/App.test.tsx` | Vitest | Clicking `[Check System]` against a healthy API moves the view out of its loading state and shows Online plus all four categories in order. |
+| UI-03 | `client/tests/lab-01/App.test.tsx` | Vitest | When the API is unavailable the view shows Offline plus a user-facing error message, and the category list does not render. |
 
-Paste your passing terminal output / screenshot below.
+**Result: 6 tests, 0 failures, 0 skipped, 0 todo.** API-02 and UI-03 each contribute
+two assertions/cases, which is why the runner reports 3 server and 3 client tests.
 
-## Issue 2 — `GET /api/health`
+## Evidence — all tests passing on `main`
 
-Server (`cd server && npm test`):
+Server, `cd server && npm test`:
 
+```text
+ ✓ tests/lab-01/health.test.ts (1 test) 16ms
+ ✓ tests/lab-01/categories.test.ts (2 tests) 151ms
+
+ Test Files  2 passed (2)
+      Tests  3 passed (3)
 ```
- ↓ tests/lab-01/categories.test.ts (1 test | 1 skipped)
- ✓ tests/lab-01/health.test.ts (1 test) 20ms
 
- Test Files  1 passed | 1 skipped (2)
-      Tests  1 passed | 1 todo (2)
-```
+Client, `cd client && npm test`:
 
-Client (`cd client && npm test`):
-
-```
- ✓ tests/lab-01/App.test.tsx (3 tests | 2 skipped) 19ms
+```text
+ ✓ tests/lab-01/App.test.tsx (3 tests) 210ms
 
  Test Files  1 passed (1)
-      Tests  1 passed | 2 todo (3)
+      Tests  3 passed (3)
 ```
 
-Live check against the running API (`curl -i http://localhost:3000/api/health`):
+`tsc --noEmit` is clean on the client. Both suites were run on `main` at commit
+`845493f`.
 
-```
-HTTP/1.1 200 OK
-Access-Control-Allow-Origin: *
-Content-Type: application/json; charset=utf-8
+## Evidence — database schema and idempotent seed
 
-{"status":"ok","service":"TokTickIT API"}
-```
-
-## Issue 3 — Category model and idempotent seed
-
-Migration `20260808153643_init` creates the table and the unique index on `name`:
+Migration `20260808153643_init`:
 
 ```sql
 CREATE TABLE "Category" (
@@ -61,21 +53,11 @@ CREATE TABLE "Category" (
 CREATE UNIQUE INDEX "Category_name_key" ON "Category"("name");
 ```
 
-Idempotency is the requirement here, so the seed was run **twice** (`npm run
-prisma:seed`). Both runs printed the same four rows with the same ids:
+The unique index on `name` is what makes the seed idempotent — it upserts on that
+column. Proven by running `npm run prisma:seed` **twice** and reading the table back
+directly in psql:
 
-```
-Seeded 4 categories:
-  1  Account and Access
-  2  Hardware
-  3  Software
-  4  Network
-```
-
-Confirmed independently in Postgres after the second run — still four rows, no
-duplicates:
-
-```
+```text
 toktickit=# SELECT id, name FROM "Category" ORDER BY id;
  id |        name
 ----+--------------------
@@ -86,49 +68,41 @@ toktickit=# SELECT id, name FROM "Category" ORDER BY id;
 (4 rows)
 ```
 
-## Issue 4 — Category list (full suite green)
+Seeding runs sequentially rather than in parallel so autoincrement ids follow the
+canonical category order on a fresh database, which is what API-02 asserts.
 
-Server (`cd server && npm test`):
+## Evidence — live API
 
-```
- ✓ tests/lab-01/health.test.ts (1 test) 16ms
- ✓ tests/lab-01/categories.test.ts (2 tests) 55ms
+```text
+$ curl -i http://localhost:3000/api/health
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+Content-Type: application/json; charset=utf-8
 
- Test Files  2 passed (2)
-      Tests  3 passed (3)
-```
-
-Client (`cd client && npm test`):
-
-```
- ✓ tests/lab-01/App.test.tsx (3 tests) 160ms
-
- Test Files  1 passed (1)
-      Tests  3 passed (3)
+{"status":"ok","service":"TokTickIT API"}
 ```
 
-**6 tests, 0 failures, 0 todo.** `tsc --noEmit` clean on the client.
-
-Live endpoint:
-
-```
+```text
 $ curl http://localhost:3000/api/categories
 [{"id":1,"name":"Account and Access"},{"id":2,"name":"Hardware"},
  {"id":3,"name":"Software"},{"id":4,"name":"Network"}]
 ```
 
-### Failure path verified for real
+## Evidence — failure path
 
-The 500 branch was exercised by stopping the Postgres container rather than by
-mocking, to confirm no internal details leak:
+The 500 branch was exercised by stopping the database container rather than by
+mocking it, to confirm no internal detail leaks:
 
-```
+```text
 $ docker stop toktickit-db
 $ curl -i http://localhost:3000/api/categories
 HTTP/1.1 500 Internal Server Error
 {"error":"Could not load categories."}
 ```
 
-The full `PrismaClientKnownRequestError` was written to the server log only. Note
-that `/api/health` still returned 200 with the database down — the lazy Prisma
-singleton means the health route never opens a connection.
+The full `PrismaClientKnownRequestError` was written to the server log only.
+
+Worth recording: `/api/health` still returned **200** with the database stopped,
+because the lazy Prisma singleton means the health route never opens a connection.
+That is intended, but it does mean a healthy response says nothing about the
+database.


### PR DESCRIPTION
Closes the three unearned-points gaps found when checking the repo against the
Lab 1 marking scheme. Documentation only — no source or test changes.

## 1. `README.md` (Part 1, 15 pts)
It was literally one line: `# TokTickIT`. The rubric asks for a rendered README
containing setup steps, so that was scoring zero.

Now covers: stack table, prerequisites, clone/install, the `docker run` command for
Postgres on 5433, env file setup with a variable table, migrate + seed, running both
dev servers, test commands, the API contract table, repository layout, the branching
model, and troubleshooting.

The troubleshooting section documents the two failure modes that actually cost time
on this project: the misleading `P1000: Authentication failed` you get from the wrong
port (because an unrelated Postgres answers on 5432), and orphaned `tsx watch`
processes silently holding port 3000.

Every command and script name was verified against the real `package.json` files
rather than written from memory.

## 2. `docs/lab-01/tests.md` (Part 2, 10 pts)
Restructured to the required schema — **Test ID / Test File Path / Tool / Test
Description** — using the `API-01`, `API-02`, `UI-01`, `UI-02`, `UI-03` identifiers
the labsheet specifies. The recorded evidence (passing output on `main`, migration
SQL, twice-run seed proof, live curl, verified 500 path) is kept beneath the table.

## 3. `docs/lab-01/ai_use.md` (Part 3, 5 pts)
Restructured to the required schema — **Prompt Name / Actual Prompt Text / My
Reflection** — and states the agent explicitly.

Two placeholders are left on purpose, because they need a human:
- the exact model string needs confirming (an earlier draft said "Claude Opus 4.8")
- the reflection column should be rewritten in the author's own voice

## Note
No test or source file is touched, so the 6 passing tests on `main` are unaffected.

@Earth2509 — thanks for the answers on #5 and #6, both were useful. One correction
worth flagging on your `.gitignore` point: `*.env` matches filenames *ending* in
`.env`, and `.env.example` ends in `.example`, so that pattern never matches it. I
tested it in a scratch repo — with only `*.env` ignored, `git check-ignore` matched
`foo.env` but not `.env.example`. So keeping `!.env.example` is good defensive
documentation, just not strictly required. Same conclusion, different reason.
