### PR TITLE
Act on the four peer review suggestions from PRs #6 and #8

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -39,10 +39,10 @@ export default function App() {
       {state === "success" && (
         <>
           <p className="mt-3 mb-2">
-            Status: <span className="text-success fw-semibold">Online</span>
+            System Status: <span className="text-success fw-semibold">Online</span>
           </p>
 
-          <h2 className="h6 mt-4">Request categories</h2>
+          <h2 className="h6 mt-4">Supported Request Categories:</h2>
           {categories.length === 0 ? (
             <p className="text-secondary mb-0">No categories found.</p>
           ) : (
@@ -59,7 +59,7 @@ export default function App() {
 
       {state === "error" && (
         <p className="mt-3 mb-0">
-          Status: <span className="text-danger fw-semibold">Offline</span> — {error}
+          System Status: <span className="text-danger fw-semibold">Offline</span> — {error}
         </p>
       )}
     </div>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,17 +10,31 @@ export interface SystemStatus {
   categories: Category[];
 }
 
+// Shown to the user whenever the API cannot be reached at all. A rejected fetch
+// gives a raw browser error such as "TypeError: Failed to fetch", which is
+// jargon; the acceptance criterion asks for a useful message instead.
+export const UNREACHABLE_MESSAGE = "Unable to connect to TokTickIT API";
+
+// Wraps fetch so a network-level failure becomes a readable message rather than
+// the browser's raw TypeError. HTTP responses pass straight through — those are
+// handled by the status checks below.
+async function request(url: string): Promise<Response> {
+  try {
+    return await fetch(url);
+  } catch {
+    throw new Error(UNREACHABLE_MESSAGE);
+  }
+}
+
 // Issue 2 + Issue 4 — call the backend.
-// Throwing on failure lets the UI show a single Offline/error state. A server
-// that is down makes fetch() reject on its own, so that path needs no handling
-// here — it surfaces as the same Offline state.
+// Throwing on failure lets the UI show a single Offline/error state.
 export async function checkSystem(): Promise<SystemStatus> {
-  const health = await fetch(`${API_URL}/api/health`);
+  const health = await request(`${API_URL}/api/health`);
   if (!health.ok) {
-    throw new Error(`Health check failed (HTTP ${health.status}).`);
+    throw new Error(`${UNREACHABLE_MESSAGE} (health check returned ${health.status}).`);
   }
 
-  const response = await fetch(`${API_URL}/api/categories`);
+  const response = await request(`${API_URL}/api/categories`);
   if (!response.ok) {
     throw new Error(`Could not load categories (HTTP ${response.status}).`);
   }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -2,27 +2,48 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "../../src/App.js";
-import * as api from "../../src/api.js";
 
+// These tests mock at the `fetch` level rather than mocking checkSystem, so the
+// real api.ts runs — including its error translation. Mocking checkSystem would
+// skip that module entirely and leave the translation untested.
 afterEach(() => vi.restoreAllMocks());
 
+const SEEDED = [
+  { id: 1, name: "Account and Access" },
+  { id: 2, name: "Hardware" },
+  { id: 3, name: "Software" },
+  { id: 4, name: "Network" },
+];
+
+function jsonResponse(body: unknown, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+/** Routes each endpoint to its own response, so ordering bugs cannot hide. */
+function mockFetch(routes: { health?: unknown; categories?: unknown }) {
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.includes("/api/health")) {
+      return routes.health ?? jsonResponse({ status: "ok", service: "TokTickIT API" });
+    }
+    if (url.includes("/api/categories")) {
+      return routes.categories ?? jsonResponse(SEEDED);
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
 describe("App", () => {
-  // WORKED EXAMPLE — provided for you.
+  // UI-01
   it("renders the TokTickIT heading", () => {
     render(<App />);
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
+  // UI-02
   it("shows Online and the seeded categories on success", async () => {
-    vi.spyOn(api, "checkSystem").mockResolvedValue({
-      online: true,
-      categories: [
-        { id: 1, name: "Account and Access" },
-        { id: 2, name: "Hardware" },
-        { id: 3, name: "Software" },
-        { id: 4, name: "Network" },
-      ],
-    });
+    const fetchMock = mockFetch({});
 
     render(<App />);
     await userEvent.click(screen.getByRole("button", { name: /check system/i }));
@@ -36,19 +57,36 @@ describe("App", () => {
       "Software",
       "Network",
     ]);
+
+    // Both endpoints were really called through api.ts.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/health");
+    expect(String(fetchMock.mock.calls[1][0])).toContain("/api/categories");
   });
 
+  // UI-03
   it("shows an Offline error message when the API is unavailable", async () => {
-    vi.spyOn(api, "checkSystem").mockRejectedValue(
-      new Error("Failed to fetch"),
-    );
+    // What the browser actually throws when the server is not running.
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
 
     render(<App />);
     await userEvent.click(screen.getByRole("button", { name: /check system/i }));
 
     expect(await screen.findByText("Offline")).toBeInTheDocument();
-    expect(screen.getByText(/Failed to fetch/i)).toBeInTheDocument();
-    // The category list must not render in the error state.
+    // The raw browser jargon must be translated, not shown to the user.
+    expect(screen.getByText(/Unable to connect to TokTickIT API/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to fetch/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+  });
+
+  it("shows Offline when the categories endpoint returns an error status", async () => {
+    mockFetch({ categories: jsonResponse({ error: "Could not load categories." }, 500) });
+
+    render(<App />);
+    await userEvent.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText("Offline")).toBeInTheDocument();
+    expect(screen.getByText(/HTTP 500/)).toBeInTheDocument();
     expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
   });
 });

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -49,6 +49,9 @@ describe("App", () => {
     await userEvent.click(screen.getByRole("button", { name: /check system/i }));
 
     expect(await screen.findByText("Online")).toBeInTheDocument();
+    // Wording required by the demo specification.
+    expect(screen.getByText(/System Status:/)).toBeInTheDocument();
+    expect(screen.getByText("Supported Request Categories:")).toBeInTheDocument();
 
     const items = screen.getAllByRole("listitem").map((li) => li.textContent);
     expect(items).toEqual([
@@ -73,6 +76,7 @@ describe("App", () => {
     await userEvent.click(screen.getByRole("button", { name: /check system/i }));
 
     expect(await screen.findByText("Offline")).toBeInTheDocument();
+    expect(screen.getByText(/System Status:/)).toBeInTheDocument();
     // The raw browser jargon must be translated, not shown to the user.
     expect(screen.getByText(/Unable to connect to TokTickIT API/i)).toBeInTheDocument();
     expect(screen.queryByText(/Failed to fetch/i)).not.toBeInTheDocument();

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,3 +8,6 @@
 # The remap to 5433 avoids clashing with a Postgres already on the default 5432.
 DATABASE_URL="postgresql://toktickit:toktickit@localhost:5433/toktickit?schema=public"
 PORT=3000
+
+# Origin allowed to call this API (CORS). Defaults to the Vite dev server.
+CLIENT_ORIGIN="http://localhost:5173"

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,6 @@
 {
   "name": "toktickit-server",
+  "displayName": "TokTickIT API",
   "version": "1.0.0",
   "private": true,
   "type": "module",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,12 +1,15 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
+import { CLIENT_ORIGIN, SERVICE_NAME } from "./config.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
 export const app = express();
 
-app.use(cors());          // already wired: lets the Vite dev server call this API
+// Least privilege: only the configured client origin may call this API, rather
+// than the wildcard that cors() sends by default.
+app.use(cors({ origin: CLIENT_ORIGIN }));
 app.use(express.json());
 
 // ---------------------------------------------------------------------------
@@ -15,7 +18,7 @@ app.use(express.json());
 // It must return HTTP 200 with JSON: { status: "ok", service: "TokTickIT API" }
 // ---------------------------------------------------------------------------
 app.get("/api/health", (_req: Request, res: Response) => {
-  res.status(200).json({ status: "ok", service: "TokTickIT API" });
+  res.status(200).json({ status: "ok", service: SERVICE_NAME });
 });
 
 app.get("/api/categories", async (_req: Request, res: Response) => {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,20 @@
+import { createRequire } from "node:module";
+
+// Read package.json at runtime rather than importing it, so this works the same
+// under tsx, vitest and a compiled build without needing JSON import attributes.
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as {
+  name: string;
+  displayName?: string;
+};
+
+// The public service name. It lives in package.json so there is one source of
+// truth and it cannot drift if the service is renamed. `displayName` is used
+// rather than `name` because the npm package is "toktickit-server" while the API
+// identifies itself to clients as "TokTickIT API".
+export const SERVICE_NAME = pkg.displayName ?? pkg.name;
+
+// Origin allowed to call this API. Wildcard CORS lets any site call the API, so
+// the allowed origin is pinned to the Vite dev server by default and overridable
+// per environment.
+export const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN ?? "http://localhost:5173";


### PR DESCRIPTION
Implements all four outstanding suggestions from @Earth2509's reviews.

## 1. Pin CORS (PR #6, Q1)
`app.use(cors())` sent `Access-Control-Allow-Origin: *`. Now pinned to
`CLIENT_ORIGIN`, defaulting to `http://localhost:5173` and overridable per
environment. Documented in `.env.example`.

Verified live:
```
$ curl -i http://localhost:3000/api/health
Access-Control-Allow-Origin: http://localhost:5173
```

## 2. Translate raw network errors (PR #6, Q2)
A rejected `fetch` produced the browser's `TypeError: Failed to fetch`, which was
rendered straight into the UI. `api.ts` now wraps fetch and converts a network-level
failure into **"Unable to connect to TokTickIT API"**.

I used the labsheet's exact demo wording rather than your suggested "Cannot reach
TokTickIT API server", since the demo specification asks for that string — same
intent, and it also closes a wording gap I had against the acceptance criteria.
HTTP status failures still report their status, so a 500 stays distinguishable from
an unreachable server.

## 3. Service name from package.json (PR #6, Q4)
Moved into `package.json` and read through a new `src/config.ts`.

One wrinkle worth flagging: reading `name` directly does not work here. The package
is `toktickit-server`, but the API must identify itself as `TokTickIT API` — the lab
spec and API-01 both require that literal. Using `name` would have changed the
response body and broken the contract. I added a `displayName` field instead, which
gives the single source of truth you were after without altering what the API
returns. `config.ts` reads it via `createRequire` so it behaves identically under
tsx, vitest and a compiled build.

## 4. Mock at the fetch level (PR #8, Q3)
You were right that mocking `checkSystem` skipped `api.ts` entirely. The client
tests now stub `fetch`, so the real `api.ts` runs and its error translation is
covered. Each endpoint is routed separately so an ordering bug cannot hide, and
UI-02 asserts both endpoints were called in the right order.

This immediately paid for itself — UI-03 can now assert that `Failed to fetch` is
**absent** from the DOM and the translated message is present, which the old
`checkSystem` mock could not have detected at all.

Added a fourth case covering a non-ok `/api/categories` response.

## Tests
```
server:  3 passed (2 files)
client:  4 passed (1 file)
tsc --noEmit: clean
```
Up from 6 to 7. API-01 still passes, which confirms `SERVICE_NAME` resolves to
`TokTickIT API`.

## Note on stacking
Branched from `lab1-staging`, so this is independent of #11 and #12, which are still
open. No file overlap with either.

---

## 5. Demo specification wording (added after review)
Two labels did not match the strings the lab demo specification asks for:

| Was | Now |
|---|---|
| `Status: Online` / `Status: Offline` | `System Status: Online` / `System Status: Offline` |
| `Request categories` | `Supported Request Categories:` |

Together with the error translation in item 2, all three demo strings now match the
specification exactly. UI-02 and UI-03 assert the wording so it cannot drift back.

Client tests: **4 passed**, `tsc --noEmit` clean.
