### PR TITLE
Issue 17: Lab 2 engineering contract and test plan

### DIFF
--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -1,0 +1,67 @@
+# Lab 2 AI Use and Reflection
+
+**Author:** Sittijed Jantarataeme — 67070501046 — @Nuggetkub
+
+| | |
+|---|---|
+| **Primary LLM** | Claude Opus 5 (`claude-opus-5`) |
+| **Platform** | Claude Code CLI, run locally against this repository |
+| **Secondary tool** | Google NotebookLM, via the `notebooklm` CLI, used to query the Lab 2 labsheet PDF |
+| **Responsibility** | Every specification, decision, business rule, test, command and submitted artefact is reviewed and approved by me. The agent drafts and investigates; I decide and remain accountable. |
+
+This record is written as the sprint proceeds rather than reconstructed at the end. It
+currently covers the engineering-contract stage (issue #17) and is completed at release
+(issue #28), when the implementation prompts are added.
+
+---
+
+## Selected Key Prompts
+
+Prompts are quoted as they were actually sent.
+
+| # | Prompt | How the result was reviewed and used |
+|---|---|---|
+| 1 | "Let's understand Lab_02_labsheet.pdf with notebooklm and check Earth2509 pull request" | The labsheet was added as a NotebookLM source and queried for objectives, deliverables, the grading table and the submission format. **I did not take the answer on trust** — the extracted PDF text was read directly and every graded claim was checked against it. NotebookLM was accurate here, including the 60-point split; it also correctly reported that the labsheet states no deadline and no filename convention, which the PDF confirmed. |
+| 2 | "write up the review for me to check before posting" | Produced a draft peer review of the partner's Lab 2 contract PR. I required it to be drafted for checking rather than posted directly. The draft's claims were verified against the partner's repository before I approved sending — one claim about a missing Project board was deliberately hedged because a private board would not be visible to me. |
+| 3 | "post it" | The review was posted as a Comment rather than an Approval, because the findings were completeness gaps against graded criteria. |
+| 4 | "draft the issue decomposition" | Produced the twelve-issue breakdown for this sprint with dependencies and branch names. I reviewed the ordering and kept the layering — contract, then theme and data, then each API before the screen that consumes it — because it makes each issue independently reviewable. |
+| 5 | "create the issues and the lab2-staging branch" | Issues #17–#28 and the `lab2-staging` branch were created. The issues were created sequentially on purpose so their numbers matched the cross-references already written into their bodies. |
+| 6 | "check Earth2509 pull request again" | Checked whether the partner had responded. He had, with a fix commit. **The commit diff was read rather than his summary of it** — the same habit that caught two stale evidence rows in his Lab 1 pull request. This time everything he claimed was genuinely there. |
+| 7 | "post the approval" | Approved his PR, with two non-blocking notes: one sentence in his `reviewer.md` had already fallen out of date, and his Project board still did not exist. |
+| 8 | "start on #17" | Produced the first draft of `specification.md`, `api-spec.md`, `tests.md`, `ui-spec.md` and this file. I directed the design decisions recorded in `specification.md` §11 and reviewed every business rule and acceptance criterion before committing. |
+
+### Deliberate constraints I placed on the agent
+
+- **Draft, then let me check, then post.** Nothing was published to my partner's repository
+  or to GitHub until I had read it. Prompt 2 exists precisely to create that gap.
+- **Verify against the source, not the summary.** Applied to the labsheet (prompt 1) and to
+  my partner's fix commit (prompt 6). Both times the instruction changed what was checked.
+- **Write this contract independently.** The agent had read my partner's Lab 2 contract in
+  detail while reviewing it. I required the design decisions here to be reasoned from the
+  labsheet rather than adapted from his, and the differences are recorded in
+  `specification.md` §11 D-12.
+
+---
+
+## My Reflection
+
+The useful lesson from Lab 1 was that an AI agent is reliable when it is *querying* a
+source and unreliable when it is *generating* claims about work it did not witness. Lab 2
+so far has reinforced both halves. NotebookLM answered questions about the labsheet
+accurately, including the grading breakdown — but I still read the PDF myself, and I would
+have done so even if it had been right the previous three times, because the cost of
+checking is minutes and the cost of not checking is submitting something false about my own
+work.
+
+The place the agent earned its keep was reviewing my partner's pull request. Reading the
+diff would have found the missing Ticket Date field. It would not have found that no GitHub
+Project board existed, or that his test plan named a Playwright command the repository had
+no way to run — those came from checking the repository against the plan, which is the same
+lesson as Lab 1, where the two real defects in his code only surfaced by cloning his branch
+and running his tests. Reviewing what someone wrote about their work is not the same as
+reviewing their work.
+
+The habit I want to carry into the implementation issues is the one in prompt 2: asking for
+a draft to check rather than an action to take. It costs one extra exchange and it is the
+only reason I caught a claim I could not actually stand behind before it went out under my
+name.

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -1,0 +1,345 @@
+# Lab 2 REST API Contract
+
+**Status:** Draft for peer review
+**Base path:** `/api`
+**Companion document:** [`specification.md`](./specification.md)
+
+---
+
+## 1. Conventions
+
+### Identity
+
+Every **requester-scoped** endpoint requires the header:
+
+```
+X-Dev-Requester-Id: <requester id>
+```
+
+This identifies the Development Requester selected in the browser. It is a Lab 2 testing
+mechanism and **is not authentication** (BR-05). The server resolves the header to an
+active Requester on every request and enforces ownership itself; a client-side selection
+is never trusted (BR-08). In Lab 3 this header is replaced by an authenticated identity
+and no path, payload or ownership rule changes (BR-44, D-01).
+
+A missing header, an unparseable value, or an id that does not resolve to an **active**
+Requester returns `401` with code `REQUESTER_CONTEXT_REQUIRED`. This is the one place a
+`401` appears, and it means "no testing context selected" rather than "not logged in".
+
+### Content types
+
+JSON requests and responses use `application/json`. Attachment upload uses
+`multipart/form-data`. Attachment download returns the stored binary with its recorded
+MIME type.
+
+### Error envelope
+
+Every error response uses one shape:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "The ticket could not be created.",
+    "fieldErrors": { "summary": "Summary must be at least 5 characters." }
+  }
+}
+```
+
+`code` is a stable machine-readable identifier that tests assert on. `message` is safe for
+display. `fieldErrors` is present only when individual fields failed, and is keyed by the
+field name the client uses.
+
+### Validation status
+
+Any invalid client input — malformed body, unknown sort field, out-of-range page size,
+failed field rule — returns **`400`** with `code: VALIDATION_FAILED` and, where
+applicable, `fieldErrors`. `422` is deliberately not used (D-03).
+
+### Safe failures
+
+An unexpected server error returns `500` with `code: INTERNAL_ERROR` and a fixed message.
+A dependency that is unavailable returns `503` with `code: DEPENDENCY_UNAVAILABLE`. Neither
+includes a stack trace, SQL, or internal path (BR-41).
+
+---
+
+## 2. Reference and Requester Endpoints
+
+These three are **not** requester-scoped and need no identity header — the selector must
+be able to load before a Requester exists.
+
+| Method and path | Purpose | Success |
+|---|---|---|
+| `GET /api/categories` | Active Categories, ordered by name | `200` `[{ "id", "name" }]` |
+| `GET /api/related-systems` | Active Related Systems, ordered by name | `200` `[{ "id", "name" }]` |
+| `GET /api/requesters` | Active Development Requesters for the selector, ordered by name | `200` `[{ "id", "fullName", "email" }]` |
+
+Inactive rows are excluded from all three (BR-06). Each returns `503` if the database is
+unreachable. An empty array is a valid answer and the interface treats it as an empty
+state rather than an error.
+
+---
+
+## 3. Ticket Endpoints
+
+### `POST /api/tickets` — create a Ticket
+
+**Headers:** `X-Dev-Requester-Id` (required), `Idempotency-Key` (required, client-generated
+UUID).
+
+**Request**
+
+```json
+{
+  "categoryId": 2,
+  "relatedSystemId": 5,
+  "summary": "Cannot connect to Campus Wi-Fi in Building 4",
+  "description": "My laptop reports authentication failure on the campus network from Monday afternoon onward. Other devices connect normally in the same room.",
+  "requestedPriority": "HIGH"
+}
+```
+
+The Requester is taken from the header, never from the body (D-01). The Ticket Number,
+Ticket Date and status are assigned by the server and are not accepted from the client
+(BR-01, BR-03, BR-04).
+
+**Success — `201`**
+
+```json
+{
+  "id": 42,
+  "ticketNumber": "TKT-2026-00042",
+  "ticketDate": "2026-08-27T09:14:22.518Z",
+  "requester": { "id": 3, "fullName": "Nadia Rahman" },
+  "category": { "id": 2, "name": "Network" },
+  "relatedSystem": { "id": 5, "name": "Campus Wi-Fi" },
+  "summary": "Cannot connect to Campus Wi-Fi in Building 4",
+  "description": "My laptop reports authentication failure ...",
+  "requestedPriority": "HIGH",
+  "currentStatus": "NEW",
+  "attachments": [],
+  "createdAt": "2026-08-27T09:14:22.518Z",
+  "updatedAt": "2026-08-27T09:14:22.518Z"
+}
+```
+
+**Idempotent replay — `200`.** Reusing an `Idempotency-Key` with an identical payload
+returns the originally created Ticket unchanged and creates nothing (BR-19). "Identical"
+means the five body fields match after the same trimming that validation applies.
+
+**Failures**
+
+| Status | `code` | When |
+|---|---|---|
+| `400` | `VALIDATION_FAILED` | Any field rule in BR-12 … BR-15 fails, or the body is malformed. `fieldErrors` names each failure. |
+| `400` | `IDEMPOTENCY_KEY_REQUIRED` | The `Idempotency-Key` header is absent or is not a UUID. |
+| `401` | `REQUESTER_CONTEXT_REQUIRED` | No valid active Requester in the identity header. |
+| `404` | `REFERENCE_NOT_FOUND` | The Category or Related System does not exist or is inactive (BR-15). |
+| `409` | `IDEMPOTENCY_KEY_CONFLICT` | The key was already used with a **different** payload. Nothing is created. |
+| `500` / `503` | `INTERNAL_ERROR` / `DEPENDENCY_UNAVAILABLE` | Safe persistence failure. The transaction rolls back, consuming no Ticket Number (BR-20). |
+
+### `GET /api/tickets` — list the selected Requester's Tickets
+
+**Headers:** `X-Dev-Requester-Id` (required).
+
+Results are scoped to that Requester before any other parameter is applied (BR-21).
+
+| Parameter | Values | Default |
+|---|---|---|
+| `search` | Trimmed substring, matched case-insensitively against Ticket Number and Summary (BR-22) | none |
+| `categoryId` | Integer, exact match | none |
+| `relatedSystemId` | Integer, exact match | none |
+| `requestedPriority` | `LOW`, `MEDIUM`, `HIGH`, `URGENT`, exact match | none |
+| `sortBy` | `ticketDate`, `ticketNumber`, `requestedPriority` | `ticketDate` |
+| `sortOrder` | `asc`, `desc` | `desc` |
+| `page` | Integer ≥ 1 | `1` |
+| `pageSize` | `10`, `25`, `50` | `10` |
+
+Ordering always appends Ticket Number descending as a tie-breaker, so paging is stable
+(BR-24). Sorting by `requestedPriority` ascending runs `LOW` → `MEDIUM` → `HIGH` →
+`URGENT`, because the column is an enum declared in that order (BR-25).
+
+There is no `currentStatus` filter in Lab 2 (BR-30, D-07).
+
+**Success — `200`**
+
+```json
+{
+  "items": [
+    {
+      "id": 42,
+      "ticketNumber": "TKT-2026-00042",
+      "ticketDate": "2026-08-27T09:14:22.518Z",
+      "summary": "Cannot connect to Campus Wi-Fi in Building 4",
+      "category": { "id": 2, "name": "Network" },
+      "relatedSystem": { "id": 5, "name": "Campus Wi-Fi" },
+      "requestedPriority": "HIGH",
+      "currentStatus": "NEW",
+      "attachmentCount": 2
+    }
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "totalItems": 1,
+  "totalPages": 1
+}
+```
+
+A page beyond the last returns `200` with an empty `items` array (BR-26). An empty result
+and a no-results result are the same response; the interface distinguishes them from
+whether a query is active (BR-29).
+
+**Failures:** `400 VALIDATION_FAILED` for an unknown `sortBy`, an unknown `sortOrder`, a
+`pageSize` outside the permitted set, a `page` below 1, or an unrecognised
+`requestedPriority` (BR-27). `401 REQUESTER_CONTEXT_REQUIRED` for a missing context.
+
+### `GET /api/tickets/:ticketId` — retrieve one owned Ticket
+
+**Headers:** `X-Dev-Requester-Id` (required).
+
+**Success — `200`** returns the same shape as the create response, including full
+`attachments` metadata with removed entries present and marked.
+
+**Failures:** `404 TICKET_NOT_FOUND` when the ticket does not exist **or** belongs to a
+different Requester — the two are indistinguishable by design (BR-10, D-04).
+`401 REQUESTER_CONTEXT_REQUIRED` for a missing context.
+
+---
+
+## 4. Attachment Endpoints
+
+All four are requester-scoped and require ownership of the parent Ticket (BR-40).
+
+### `POST /api/tickets/:ticketId/attachments` — upload
+
+**Headers:** `X-Dev-Requester-Id` (required).
+**Body:** `multipart/form-data` with one field `file`.
+
+The server verifies the type from the file's content rather than its extension (BR-31),
+enforces the 5 MB ceiling (BR-32) and the five-active limit (BR-33), then writes the file
+under a generated `storageKey` (BR-35).
+
+**Success — `201`**
+
+```json
+{
+  "id": 7,
+  "originalFilename": "wifi-error.png",
+  "mimeType": "image/png",
+  "sizeBytes": 184203,
+  "uploadedAt": "2026-08-27T09:20:41.004Z",
+  "removedAt": null
+}
+```
+
+**Failures**
+
+| Status | `code` | When |
+|---|---|---|
+| `400` | `VALIDATION_FAILED` | No file part, or a malformed multipart request. |
+| `401` | `REQUESTER_CONTEXT_REQUIRED` | No valid active Requester. |
+| `404` | `TICKET_NOT_FOUND` | Ticket missing or owned by someone else. |
+| `409` | `ATTACHMENT_LIMIT_REACHED` | Five active attachments already exist (BR-33). |
+| `413` | `ATTACHMENT_TOO_LARGE` | Over 5 MB (BR-32). |
+| `415` | `ATTACHMENT_TYPE_NOT_ALLOWED` | Content is not JPEG, PNG, WEBP or PDF (BR-31). |
+| `500` / `503` | `INTERNAL_ERROR` / `DEPENDENCY_UNAVAILABLE` | Storage failure. No metadata row is written and the ticket is untouched (BR-36). |
+
+### `GET /api/tickets/:ticketId/attachments` — metadata
+
+**Headers:** `X-Dev-Requester-Id` (required).
+
+**Success — `200`** an array of attachment metadata for an owned Ticket, **including
+removed entries**, each carrying `removedAt`, `removedByRequesterId` and `removalReason`
+when removed. `storageKey` is never returned.
+
+**Failures:** `404 TICKET_NOT_FOUND`, `401 REQUESTER_CONTEXT_REQUIRED`.
+
+### `GET /api/tickets/:ticketId/attachments/:attachmentId/download` — download
+
+**Headers:** `X-Dev-Requester-Id` (required).
+
+**Success — `200`** the file bytes, with `Content-Type` set from the recorded MIME type
+and `Content-Disposition: attachment; filename="<sanitised original filename>"`.
+
+**Failures:** `404 ATTACHMENT_NOT_FOUND` when the attachment does not exist, belongs to
+another Requester's ticket, **or has been removed** — a removed file is not downloadable by
+anyone (BR-39). `401 REQUESTER_CONTEXT_REQUIRED`.
+
+### `PATCH /api/tickets/:ticketId/attachments/:attachmentId` — soft remove
+
+**Headers:** `X-Dev-Requester-Id` (required).
+
+**Request**
+
+```json
+{ "removalReason": "Uploaded the wrong screenshot; it shows another person's account." }
+```
+
+**Success — `200`**
+
+```json
+{
+  "id": 7,
+  "originalFilename": "wifi-error.png",
+  "mimeType": "image/png",
+  "sizeBytes": 184203,
+  "uploadedAt": "2026-08-27T09:20:41.004Z",
+  "removedAt": "2026-08-27T09:33:10.221Z",
+  "removedByRequesterId": 3,
+  "removalReason": "Uploaded the wrong screenshot; it shows another person's account."
+}
+```
+
+The metadata row is retained and the file becomes undownloadable (BR-37, BR-39). The
+stored bytes are not deleted in Lab 2, because a removal reason implies an audit trail
+that a hard delete would destroy.
+
+**Failures**
+
+| Status | `code` | When |
+|---|---|---|
+| `400` | `VALIDATION_FAILED` | Reason missing, or outside 5–250 characters after trimming (BR-38). |
+| `401` | `REQUESTER_CONTEXT_REQUIRED` | No valid active Requester. |
+| `404` | `ATTACHMENT_NOT_FOUND` | Missing, or on another Requester's ticket. |
+| `409` | `ATTACHMENT_ALREADY_REMOVED` | The attachment is already removed. The first removal's reason and timestamp are authoritative and are not overwritten. |
+| `500` / `503` | `INTERNAL_ERROR` / `DEPENDENCY_UNAVAILABLE` | Safe failure; nothing changes. |
+
+---
+
+## 5. Status Code Summary
+
+| Status | Meaning in Lab 2 |
+|---|---|
+| `200` | Successful retrieval, idempotent create replay, or successful soft removal |
+| `201` | Ticket or Attachment created |
+| `400` | Any invalid client input, with `fieldErrors` where applicable (D-03) |
+| `401` | No valid Development Requester context in `X-Dev-Requester-Id` |
+| `404` | Missing, inactive, or not owned — deliberately indistinguishable (D-04) |
+| `409` | Idempotency key conflict, attachment limit reached, or already removed |
+| `413` | Attachment over 5 MB |
+| `415` | Attachment type not permitted |
+| `500` | Unexpected server error, safely worded |
+| `503` | Database or storage unavailable, safely worded |
+
+`403` is never returned: an ownership failure is reported as `404` so the response does not
+confirm that another Requester's resource exists.
+
+---
+
+## 6. Capability Coverage
+
+The ten capabilities the labsheet requires, mapped to the endpoints above:
+
+| Required capability | Endpoint |
+|---|---|
+| Retrieve active Categories | `GET /api/categories` |
+| Retrieve active Related Systems | `GET /api/related-systems` |
+| Retrieve active Development Requesters | `GET /api/requesters` |
+| Create a Ticket | `POST /api/tickets` |
+| Retrieve the selected Requester's Tickets | `GET /api/tickets` |
+| Retrieve one owned Ticket | `GET /api/tickets/:ticketId` |
+| Upload an Attachment | `POST /api/tickets/:ticketId/attachments` |
+| Retrieve Attachment metadata | `GET /api/tickets/:ticketId/attachments` |
+| Download an active Attachment | `GET /api/tickets/:ticketId/attachments/:attachmentId/download` |
+| Soft-remove an Attachment | `PATCH /api/tickets/:ticketId/attachments/:attachmentId` |

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -1,0 +1,44 @@
+# Lab 2 Peer Review Record
+
+**Author:** Sittijed Jantarataeme — Student ID 67070501046 — GitHub [@Nuggetkub](https://github.com/Nuggetkub)
+**Peer reviewer:** Pattharapon Kijjanukij — Student ID 67070501069 — GitHub [@Earth2509](https://github.com/Earth2509)
+
+Both students review each other's work. This record is written from actual GitHub activity
+only — every row below corresponds to a real review, comment, or merge that can be opened
+at the linked URL. No approval is recorded before it happens.
+
+## Review Workflow
+
+Each Lab 2 issue is implemented on its own feature branch and enters `lab2-staging` through
+a peer-reviewed Pull Request. The release Pull Request from `lab2-staging` to `main`
+requires review and approval as well. Both branches are protected: one approving review is
+required, stale approvals are dismissed on a new push, and the rule is enforced for the
+repository owner too, so an unreviewed merge is not possible.
+
+---
+
+## Reviews Received on My Pull Requests
+
+| Issue / Pull Request | Scope | Reviewer feedback | Author response | Outcome |
+|---|---|---|---|---|
+| [#17](https://github.com/Nuggetkub/toktickit/issues/17) / [PR #29](https://github.com/Nuggetkub/toktickit/pull/29) | Lab 2 engineering contract and test plan | @Earth2509 reviewed on 2026-08-27 and found the specification, API, test, UI and AI-use documents thorough and internally consistent, but **withheld approval because `docs/lab-02/reviewer.md` was missing.** The labsheet §12 lists it as one of the six required documents in the Lab 2 repository increment; the pull request shipped only five. | The finding is correct. `reviewer.md` had been scheduled against the release issue [#28](https://github.com/Nuggetkub/toktickit/issues/28) rather than the contract issue, which misread §12. This file was added to the same branch and re-review requested. | **Pending re-review.** |
+
+---
+
+## Reviews I Gave on My Peer's Pull Requests
+
+| Pull Request | Feedback given | Peer response | Outcome |
+|---|---|---|---|
+| [Earth2509/toktickit PR #12](https://github.com/Earth2509/toktickit/pull/12) — Lab 2 engineering contract and test plan | Reviewed as a **Comment** on 2026-08-26, not an approval. Eight findings: Ticket Date was absent from the Create Ticket layout although labsheet §4.4 requires it on that screen; `reviewer.md` recorded only reviews received, with no section for reviews given and no PR links, which Part 1 asks for; `sortBy=requestedPriority` had no defined ordering, so a string column would have sorted `HIGH, LOW, MEDIUM, URGENT` alphabetically; the Current Status filter could never change a result set, since every Lab 2 ticket is `NEW`; the planned Playwright suite had no owning issue and the repository had no Playwright config, dependency or `e2e/` directory; no GitHub Project board could be found, which Part 1 grades; `ai-use.md` listed prompt *purposes* rather than the prompts themselves; and validation returned `422` on create but `400` on the list query, with `idempotencyKey` neither marked required nor defining what made a key "conflicting". | Replied on 2026-08-27 and pushed commit `2b50480` addressing all eight. Verified against the commit diff rather than the summary: the priority enum was declared in severity order with ascending and descending documented, idempotency conflict was defined as a differing normalized payload, the `400`/`422` split was explained, Ticket Date was added with reserved pre-submission positions, `reviewer.md` was split into reviews received and reviews given with working links, prompts were replaced with quoted text, and the E2E infrastructure dependency was documented. | **Approved 2026-08-27**, with two non-blocking notes: one sentence in his `reviewer.md` had already fallen out of date, and the Project board still did not exist. Merged by the author on 2026-08-27. |
+
+---
+
+## Notes
+
+- Two review directions are recorded deliberately. Part 1 asks for "comments given and
+  received", and a record that shows only one direction is incomplete regardless of how
+  much detail it carries.
+- Reviews are recorded when they happen rather than reconstructed at release. A row written
+  three weeks later tends to describe what was intended rather than what occurred — a
+  failure this project has already seen once, in the Lab 1 review record, where a row still
+  read "review in progress" after the pull request had merged.

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -1,0 +1,415 @@
+# Lab 2 Sprint Engineering Specification
+
+**Status:** Draft for peer review
+**Issue:** [#17 Sprint specification and test plan](https://github.com/Nuggetkub/toktickit/issues/17)
+**Branch:** `feature/17-engineering-contract`
+**Author:** Sittijed Jantarataeme — 67070501046 — @Nuggetkub
+**Peer reviewer:** Pattharapon Kijjanukij — 67070501069 — @Earth2509
+
+This document is the engineering contract for Sprint 2. It is written before
+implementation and updated through the sprint. The coding agent may report a feature
+"done" only when the contract is satisfied and the required tests pass.
+
+---
+
+## 1. Sprint Goal
+
+Deliver the Requester-facing half of TokTickIT: a person picked from a temporary
+Development Requester selector can raise an IT support ticket, receive an official
+backend-generated Ticket Number, attach supporting evidence, find their own tickets
+again through search, filtering, sorting and paging, open a read-only Ticket Detail
+screen, and manage the attachments on their own tickets. Every screen is built from one
+reusable Zen Green component set that later labs extend rather than replace.
+
+## 2. Stakeholder Request Interpretation
+
+The stakeholder asked for a professional, responsive ticketing experience for end users,
+with a temporary way to choose "who is logged in" until real authentication arrives in
+Lab 3. Four things in that request are load-bearing and are treated as requirements
+rather than preferences:
+
+1. **The system generates the official Ticket Number**, not the browser. The number is
+   the record's public identity, so it must be produced server-side and be unique.
+2. **One Requester must not see another Requester's ticket.** The selector is a testing
+   convenience and is trivially forgeable, so ownership is enforced on the server for
+   every requester-scoped operation. The client-side selection is never trusted.
+3. **Attachments have a lifecycle, not just an upload.** Evidence must be addable to an
+   existing ticket, downloadable while active, and removable in a way that preserves the
+   audit trail — which is why removal is soft and requires a reason.
+4. **The Zen Green conventions are an asset for later labs.** Form, list, badge,
+   validation, loading, empty, error and responsive behaviour are specified once here so
+   that Lab 3's IT Staff screens inherit them.
+
+The request is deliberately incomplete on validation limits, query semantics, storage
+strategy and failure behaviour. Those gaps are resolved in this document and recorded in
+§11.
+
+## 3. Scope
+
+### Included
+
+- Development Requester selection, switching, display, and the guarded routes behind it.
+- Create Ticket: reference data, validation, submission, official Ticket Number, and the
+  full set of loading, success and failure states.
+- My Tickets: requester-scoped list with search, filters, sorting, pagination, and
+  distinct empty and no-results states.
+- Requester Ticket Detail in read-only view mode.
+- Attachment lifecycle: upload, metadata, download, and soft removal with a reason.
+- PostgreSQL and Prisma models, one migration, and a repeatable seed.
+- REST API covering the ten required capabilities.
+- Automated unit, API, UI component, UI style, responsive and end-to-end tests.
+- The Zen Green visual specification and its inspection checklist.
+
+### Excluded
+
+Deferred to Lab 3 or later, and deliberately absent from this sprint:
+
+- Real authentication: login, logout, passwords, password hashing, sessions, tokens,
+  authenticated identity, and role-based authorization. **The Development Requester
+  selector is a testing mechanism and is not security.**
+- IT Staff workflow: staff dashboard and queue, claiming or reassigning tickets, setting
+  IT Priority, and any other ticket-owner function.
+- Ticket collaboration: Public Comments, Internal Notes, and Actions Taken.
+- Ticket lifecycle after creation: any status change beyond the initial `NEW`, including
+  resolution confirmation, resolving, closing, reopening and cancelling.
+- Administration: management of users, requesters, roles, or reference data.
+
+## 4. Functional Requirements
+
+- **FR-01** The system shall list active Development Requesters for selection and shall
+  exclude inactive ones.
+- **FR-02** The system shall require a selected Development Requester before any
+  requester-scoped screen can be used, and shall return an unselected visitor to the
+  selector.
+- **FR-03** The application shell shall display the selected Requester and shall provide
+  a Change Requester action that clears requester-scoped state.
+- **FR-04** The Create Ticket screen shall load active Categories and active Related
+  Systems from the backend.
+- **FR-05** The backend shall validate a submitted ticket, persist exactly one Ticket for
+  the selected Requester, generate its official Ticket Number, and return the saved
+  record.
+- **FR-06** The system shall prevent a repeated submission of the same ticket from
+  creating a duplicate.
+- **FR-07** The My Tickets screen shall list only tickets owned by the selected Requester
+  and shall support search, filtering, sorting and pagination.
+- **FR-08** The Ticket Detail screen shall display one owned ticket read-only, and shall
+  refuse a ticket owned by anyone else.
+- **FR-09** A Requester shall add a permitted attachment to a ticket they own.
+- **FR-10** A Requester shall download an active attachment on a ticket they own.
+- **FR-11** A Requester shall soft-remove an active attachment on a ticket they own,
+  supplying a removal reason.
+- **FR-12** The interface shall present explicit loading, validation, submitting, success,
+  empty, no-results and safe-failure states at desktop, tablet and mobile widths.
+
+## 5. Business Rules
+
+### Ticket identity and defaults
+
+- **BR-01** The official Ticket Number is generated by the backend and is unique across
+  the system. The client never supplies or predicts it.
+- **BR-02** The Ticket Number format is `TKT-<YYYY>-<NNNNN>`, where `<YYYY>` is the
+  creation year and `<NNNNN>` is a zero-padded per-year sequence, for example
+  `TKT-2026-00042`.
+- **BR-03** A new Ticket begins with Current Status `NEW`. Lab 2 exposes no transition
+  away from `NEW`.
+- **BR-04** Ticket Date is the server-assigned creation timestamp. It is read-only and is
+  displayed on Create Ticket after a successful save and on Ticket Detail.
+
+### Requester selection and ownership
+
+- **BR-05** Lab 2 uses a Development Requester selector in place of login. The selected
+  identity is a testing context and is **not** authentication.
+- **BR-06** Only active Requesters appear in the selector. An inactive Requester cannot be
+  selected and cannot become the active context.
+- **BR-07** The browser stores only the selected Requester's identifier. No credential,
+  token, or password is stored, because none exists in this sprint.
+- **BR-08** Every requester-scoped API request carries the selected Requester in the
+  `X-Dev-Requester-Id` request header. The server resolves and validates it on every such
+  request; the client's claim is never trusted on its own.
+- **BR-09** A Ticket belongs to exactly one Requester, fixed at creation and never
+  reassigned in Lab 2.
+- **BR-10** A request for a Ticket or Attachment owned by a different Requester is
+  answered as **not found**, not as forbidden, so that the response does not confirm the
+  resource exists.
+- **BR-11** Changing Requester clears requester-scoped client state — list filters, paging
+  and any cached ticket — before the replacement context loads.
+
+### Validation
+
+- **BR-12** Ticket Summary is required. It is trimmed before validation and must be 5 to
+  120 characters after trimming. The limit keeps a summary readable as one line in the My
+  Tickets table at tablet width.
+- **BR-13** Description is required. It is trimmed before validation and must be 20 to
+  4000 characters after trimming. The lower bound exists because a one-word description
+  cannot be actioned by IT staff in Lab 3.
+- **BR-14** Requested Priority is required and must be one of `LOW`, `MEDIUM`, `HIGH`,
+  `URGENT`.
+- **BR-15** Category and Related System are required, must exist, and must be active at
+  the moment of creation.
+- **BR-16** Validation runs on both the client and the server. The client provides
+  immediate field-level feedback; the server re-validates every rule and is the authority,
+  because the client can be bypassed.
+- **BR-17** A validation failure creates nothing, returns field-level errors keyed by
+  field name, and leaves the submitted values intact in the form.
+
+### Duplicate submission
+
+- **BR-18** The submit control is disabled while a submission is in flight.
+- **BR-19** Every create request carries an `Idempotency-Key` header holding a
+  client-generated UUID. Replaying that key with an identical ticket payload returns the
+  originally created Ticket and creates nothing further. Replaying it with a different
+  payload is a conflict and creates nothing.
+- **BR-20** The Ticket row and its official number are written in one database
+  transaction. A failure rolls back both, so a number is never consumed by a ticket that
+  does not exist.
+
+### Search, filtering, sorting and pagination
+
+- **BR-21** My Tickets is scoped to the selected Requester before any other filter is
+  applied.
+- **BR-22** Search matches Ticket Number and Ticket Summary, case-insensitively, on a
+  trimmed substring.
+- **BR-23** Filters are exact matches on Category, Related System and Requested Priority.
+- **BR-24** Sorting is permitted on Ticket Date, Ticket Number and Requested Priority. The
+  default is Ticket Date descending, with Ticket Number descending as the tie-breaker so
+  that ordering is stable across pages.
+- **BR-25** Requested Priority is a Postgres enum declared in severity order `LOW`,
+  `MEDIUM`, `HIGH`, `URGENT`. Ascending sort therefore runs least to most severe rather
+  than alphabetically.
+- **BR-26** Pages are numbered from 1. Permitted page sizes are 10, 25 and 50; the default
+  is 10. An out-of-range page returns an empty result set rather than an error.
+- **BR-27** An unrecognised sort field, sort direction, page size, or filter value is
+  rejected with a field-level error rather than silently ignored, so that a typo in a
+  query cannot masquerade as a legitimate empty result.
+- **BR-28** The list response carries `page`, `pageSize`, `totalItems` and `totalPages`
+  alongside the items.
+- **BR-29** The interface distinguishes an **empty** list — this Requester owns no tickets
+  — from **no results** — a search or filter matched nothing. They carry different
+  explanations and different recovery actions.
+- **BR-30** Current Status is not offered as a filter in Lab 2. Every ticket in this
+  sprint is `NEW`, so the control could never change a result set; it is introduced in
+  Lab 3 with the statuses that make it meaningful.
+
+### Attachments
+
+- **BR-31** Permitted attachment types are JPEG, PNG, WEBP and PDF. The server determines
+  the type from the file's own content, not from its filename extension.
+- **BR-32** Each attachment must not exceed 5 MB.
+- **BR-33** A Ticket may hold at most five **active** attachments. Soft-removed
+  attachments do not count toward the limit.
+- **BR-34** Attachments are uploaded to a Ticket that already exists. Ticket creation and
+  attachment upload are separate operations, so an upload failure never costs the user a
+  valid ticket.
+- **BR-35** Stored attachments are written under a server-generated storage key. The
+  original filename is display and download metadata only and is never used to build a
+  server path.
+- **BR-36** A failed upload stores no metadata row, leaves the ticket and its other
+  attachments untouched, and reports which file failed and why.
+- **BR-37** Removal is soft. It records the removal timestamp, the removing Requester and
+  a removal reason, and it never deletes the metadata row.
+- **BR-38** The removal reason is required, trimmed, and must be 5 to 250 characters.
+- **BR-39** A removed attachment remains visible in Ticket Detail as metadata marked
+  Removed, and cannot be downloaded or previewed by anyone.
+- **BR-40** Only the owner of a Ticket may upload to it, download from it, or remove its
+  attachments.
+
+### Failure behaviour
+
+- **BR-41** An unexpected server error returns a safe message with no stack trace, SQL, or
+  internal path.
+- **BR-42** A failed request never discards what the user typed. Create Ticket keeps its
+  field values and the user can retry without re-entering them.
+- **BR-43** Raw browser network errors — for example `TypeError: Failed to fetch` — are
+  translated at the API client boundary into a human message before they reach the
+  interface.
+
+### Transition to Lab 3
+
+- **BR-44** The `X-Dev-Requester-Id` header is the single seam where identity enters the
+  system. In Lab 3 it is replaced by an authenticated identity resolved from a session or
+  token, and no endpoint path, payload, or ownership rule needs to change.
+- **BR-45** The Ticket-to-Requester ownership relationship persists unchanged into Lab 3;
+  the authenticated user becomes the Requester rather than replacing the concept.
+
+## 6. UI Specification Summary
+
+The full visual contract is in [`ui-spec.md`](./ui-spec.md). In summary: the Zen Green
+palette is fixed by the labsheet — primary `#006B3C`, secondary `#0B7A46`, pale
+`#EAF6EF`, page background `#F5F7F6`, white surfaces, dark charcoal-green text, dark red
+errors, amber warnings. Labels sit above their controls, required fields carry an
+asterisk, and validation messages appear directly beneath the field they concern rather
+than as a single message at the top of the form. Read-only fields are visually distinct
+from editable ones. Buttons always carry text, and every state — primary, secondary,
+tertiary, destructive, disabled, busy — is defined once and reused. Loading and success
+are announced through `role="status"`; actionable failures use `role="alert"`. Layout is
+multi-column at 992 px and wider, two-column where practical from 768 to 991 px, and
+stacked below 768 px with no page-level horizontal scrolling.
+
+## 7. Data Changes
+
+### Models
+
+| Model | Fields | Notes |
+|---|---|---|
+| `Requester` | `id`, `fullName`, `email` (unique), `isActive`, `createdAt`, `updatedAt` | Owns tickets. The persistent identity that Lab 3 authentication will attach to. |
+| `Category` | existing `id`, `name` (unique), `createdAt`; **add** `isActive` | Lab 1 model, extended so retrieval can be limited to active rows. |
+| `RelatedSystem` | `id`, `name` (unique), `isActive`, `createdAt`, `updatedAt` | The specific service, application or device a ticket concerns. |
+| `Ticket` | `id`, `ticketNumber` (unique), `requesterId`, `categoryId`, `relatedSystemId`, `summary`, `description`, `requestedPriority`, `currentStatus`, `idempotencyKey` (unique, nullable), `createdAt`, `updatedAt` | `createdAt` is the Ticket Date. |
+| `Attachment` | `id`, `ticketId`, `storageKey` (unique), `originalFilename`, `mimeType`, `sizeBytes`, `uploadedAt`, `removedAt`, `removedByRequesterId`, `removalReason` | The four removal-related columns are nullable; a row with `removedAt = NULL` is active. |
+
+### Enums
+
+```prisma
+enum RequestedPriority { LOW MEDIUM HIGH URGENT }
+enum TicketStatus      { NEW }
+```
+
+`RequestedPriority` is declared in severity order so that Postgres orders it by severity
+rather than alphabetically (BR-25). `TicketStatus` holds only `NEW` in Lab 2; Lab 3 adds
+its remaining members without a data migration.
+
+### Relationships
+
+- `Requester` 1—∞ `Ticket`
+- `Ticket` 1—∞ `Attachment`
+- `Category` 1—∞ `Ticket`
+- `RelatedSystem` 1—∞ `Ticket`
+- `Requester` 1—∞ `Attachment` through `removedByRequesterId`, recording who removed what
+
+### Constraints and indexes
+
+| Decision | Reason |
+|---|---|
+| Unique `Ticket.ticketNumber` | It is the record's public identity (BR-01). |
+| Unique `Ticket.idempotencyKey`, nullable | Enforces BR-19 at the database level rather than trusting application logic. Postgres permits many `NULL`s, so tickets created by other means are unaffected. |
+| Unique `Requester.email`, `Category.name`, `RelatedSystem.name` | Gives the seed a natural key to upsert on, which is what makes reruns idempotent. |
+| Unique `Attachment.storageKey` | Two rows must never point at one file on disk. |
+| Index on `Ticket(requesterId, createdAt DESC)` | Every My Tickets query filters by requester and orders by date; this is the query the index exists for. |
+| Index on `Ticket(categoryId)` and `Ticket(relatedSystemId)` | Supports the two exact-match filters. |
+| Index on `Attachment(ticketId, removedAt)` | The active-attachment count in BR-33 is the hottest attachment query. |
+
+**Justified design decision.** Soft removal is represented by nullable removal columns on
+`Attachment` rather than by an `isRemoved` boolean or a separate `RemovedAttachment`
+table. A boolean would record *that* a file was removed but not *when*, *by whom*, or
+*why*, which BR-37 requires. A separate table would split one concept across two
+relations and make "list all attachments, marking removed ones" a union query on the
+screen that needs it most. Nullable columns keep the audit trail on the row it describes,
+and `removedAt IS NULL` is a single, indexable definition of "active" used identically by
+the list query, the download guard and the five-attachment count.
+
+### Migration
+
+One additive migration. `Category` gains `isActive` with default `true`, so existing Lab 1
+rows remain valid and the migration needs no backfill. No column is dropped or renamed.
+
+### Seed
+
+The seed is idempotent: it upserts on the unique natural keys above, so running it twice
+produces no duplicates and no errors. It creates:
+
+- the four required Categories: **Account and Access**, **Hardware**, **Software**,
+  **Network**;
+- at least six Related Systems: Email, Campus Wi-Fi, VPN, LEB2 App, Grade Submission App,
+  Printer, and Corporate Laptop;
+- four **active** Development Requesters with realistic names and e-mail addresses;
+- one **inactive** Development Requester, which must never appear in the selector (BR-06).
+
+The seed creates no tickets. Every ticket that exists during evidence capture was created
+through the application, which is what makes the Part 6 and Part 7 screenshots evidence
+of working software rather than of seed data.
+
+## 8. API Contract
+
+The full contract — paths, parameters, payloads, responses, status codes and errors — is
+in [`api-spec.md`](./api-spec.md). It covers the ten required capabilities: active
+Categories, active Related Systems, active Development Requesters, create Ticket, list the
+selected Requester's Tickets, retrieve one owned Ticket, upload an Attachment, list
+Attachment metadata, download an active Attachment, and soft-remove an Attachment.
+
+## 9. Acceptance Criteria
+
+- **AC-01** Given four active and one inactive Requester are seeded, when the selector
+  loads, then the four active Requesters are offered, the inactive one is absent, and the
+  screen states that this is a testing mechanism rather than a login.
+- **AC-02** Given no Requester has been selected, when a requester-scoped route is opened
+  directly, then the selector is shown instead of any ticket data.
+- **AC-03** Given a Requester is selected, when Create Ticket opens, then Categories and
+  Related Systems are loaded from the backend and the Requester field shows the selected
+  person as read-only.
+- **AC-04** Given a valid ticket form, when it is submitted, then exactly one Ticket is
+  saved with the selected `requesterId`, status `NEW`, a server-assigned Ticket Date, and
+  an official Ticket Number matching `TKT-<YYYY>-<NNNNN>`, and that number is displayed.
+- **AC-05** Given an invalid ticket form, when submission is attempted, then each invalid
+  field shows its own message beneath it, nothing is created, and the entered values
+  remain.
+- **AC-06** Given a create request is retried with the same `Idempotency-Key` and an
+  identical payload, when it reaches the server, then the originally created Ticket is
+  returned and no second Ticket exists.
+- **AC-07** Given the backend is unreachable, when a ticket is submitted, then a safe
+  error message is shown with no raw network text, and every entered value is preserved
+  for retry.
+- **AC-08** Given Requester A owns tickets, when My Tickets loads for A and the selection
+  is then changed to Requester B, then A's tickets are listed for A and are absent for B.
+- **AC-09** Given a Requester owns tickets, when a search term, a filter, a sort or a page
+  is applied, then the returned set matches that query, remains scoped to the Requester,
+  and the response reports `page`, `pageSize`, `totalItems` and `totalPages`.
+- **AC-10** Given sorting by Requested Priority ascending, when the list renders, then
+  tickets appear in severity order `LOW`, `MEDIUM`, `HIGH`, `URGENT` rather than
+  alphabetical order.
+- **AC-11** Given a Requester who owns no tickets and, separately, a filter that matches
+  none, when My Tickets renders, then the two situations show different messages and
+  different recovery actions.
+- **AC-12** Given Requester B requests a Ticket or Attachment owned by Requester A, when
+  the request reaches the server, then it is answered as not found and no ticket data is
+  disclosed.
+- **AC-13** Given an owned Ticket with fewer than five active attachments, when a
+  permitted file of 5 MB or less is uploaded, then it is stored under a server-generated
+  key and appears as active metadata.
+- **AC-14** Given an owned Ticket, when an unsupported type, an oversize file, or a sixth
+  active attachment is uploaded, then the upload is rejected with a message naming the
+  reason, and no metadata row is created.
+- **AC-15** Given an active attachment on an owned Ticket, when it is soft-removed with a
+  valid reason, then it is marked Removed with a timestamp, remover and reason, its
+  metadata remains visible, and a subsequent download of it is refused.
+- **AC-16** Given Create Ticket, My Tickets and Ticket Detail at desktop, tablet and
+  mobile widths, when each renders, then labels, controls, validation messages and
+  attachment names are fully visible, nothing overlaps or is clipped, and the page does
+  not scroll horizontally.
+
+## 10. Definition of Done
+
+A Lab 2 feature is done when **all** of the following hold:
+
+1. The behaviour matches this specification, and any deviation has been agreed and
+   recorded here first.
+2. Its acceptance criteria are covered by automated tests at the levels named in
+   [`tests.md`](./tests.md), and those tests pass.
+3. No test is skipped, disabled, weakened, or replaced by an assertion that cannot fail.
+4. The Prisma schema, one migration, and the idempotent seed match §7.
+5. The API matches [`api-spec.md`](./api-spec.md), including validation, ownership,
+   status codes and safe errors.
+6. The interface matches [`ui-spec.md`](./ui-spec.md) at all three viewports, and the
+   visual inspection checklist is completed against the real screens.
+7. The work reached `lab2-staging` through a peer-reviewed Pull Request from its own
+   feature branch, with the review recorded in [`reviewer.md`](./reviewer.md).
+8. Documentation — this file, `tests.md`, `ui-spec.md`, `api-spec.md`, `ai-use.md` and the
+   README — reflects what was actually built.
+9. The final unit, API and UI test output in `tests.md` was captured from `main` after the
+   release merge, not from a feature branch.
+
+## 11. Assumptions and Decisions
+
+| # | Decision | Reasoning |
+|---|---|---|
+| D-01 | The selected Requester travels in an `X-Dev-Requester-Id` header rather than as a query parameter or body field on every endpoint. | It keeps identity out of the resource's own payload, so `POST /api/tickets` describes a ticket and nothing else. It also gives ownership checks one place to live — a single middleware — and makes Lab 3 a substitution at that seam rather than a change to every route signature (BR-44). |
+| D-02 | Idempotency travels in an `Idempotency-Key` header rather than in the request body. | Same reasoning as D-01: it is transport metadata, not part of the ticket. It also matches the convention most payment and messaging APIs use, so it is a recognisable pattern rather than a local invention. |
+| D-03 | Every invalid client input returns `400` with `fieldErrors`, and `422` is not used. | One rule is easier to implement consistently and to test than a split between malformed and semantically invalid input, and the boundary between those two is genuinely ambiguous for a JSON body. The response body, not the status code, tells the client which fields failed. |
+| D-04 | Cross-requester access returns `404`, never `403`. | A `403` confirms the resource exists, which is itself a disclosure. `404` is indistinguishable from a wrong identifier (BR-10). |
+| D-05 | Ticket creation and attachment upload are separate requests. | A ticket is worth keeping even when one file fails to upload. Combining them would mean either losing a valid ticket to a transient upload failure or accepting a partially-created ticket, and neither is defensible (BR-34). |
+| D-06 | Attachments are stored on the server filesystem under a generated key, with metadata in Postgres. | Keeping binaries out of the database keeps backups and query performance sane, and the generated key removes any path built from user input (BR-35). The storage boundary is behind an interface so Lab 3 can move to object storage without touching the routes. |
+| D-07 | Current Status is not exposed as a filter in Lab 2. | Every ticket is `NEW` (BR-03), so the control could never change a result set. Shipping a filter that cannot filter is worse than omitting it, and Part 7 evidence uses Category, Related System and Requested Priority instead (BR-30). |
+| D-08 | Requested Priority is a Postgres enum declared in severity order. | A string column sorts alphabetically — `HIGH`, `LOW`, `MEDIUM`, `URGENT` — which is meaningless to a user. Declaration order gives severity sorting with no application-side comparator (BR-25). |
+| D-09 | Summary is 5–120 characters; Description is 20–4000. | The Summary bound keeps one line readable in the tablet-width table; the Description lower bound exists because Lab 3's IT staff must be able to act on it. Both are enforced after trimming so that whitespace cannot satisfy them. |
+| D-10 | Page sizes are 10, 25 and 50, defaulting to 10. | A closed set keeps the query bounded, which prevents a hand-edited `pageSize` from becoming an accidental denial of service. |
+| D-11 | The seed creates no tickets. | Tickets in the evidence screenshots must have come through the application, or the screenshots prove nothing about the software. |
+| D-12 | This contract was written independently of the peer's Lab 2 contract, which was reviewed on 2026-08-26 in `Earth2509/toktickit` PR #12. | Both derive from the same labsheet, so fixed constraints — the palette, the attachment limits, the four categories, the breakpoints — necessarily agree. The decisions above are this repository's own: the header-based identity seam, the single `400` rule, the omitted status filter, the storage strategy, and the validation bounds all differ from the peer's. |

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -1,0 +1,173 @@
+# Lab 2 Test Plan and Results
+
+**Status:** Planned before implementation
+**Companion document:** [`specification.md`](./specification.md)
+**Status convention:** a row reads `Planned` until that test has actually run and passed
+on `main`. Nothing is marked `Passed` from a feature branch.
+
+---
+
+## 1. Test Strategy
+
+Tests are derived from the acceptance criteria in `specification.md` §9, written before or
+alongside the code they cover, and organised by the level that can prove the behaviour most
+cheaply.
+
+- **Unit** — pure logic with no database or network: number formatting, validation bounds,
+  query-parameter parsing, attachment rules. Fast, and the right place for boundary cases.
+- **API** — Express routes exercised through Supertest against a test database, asserting
+  status codes, the `error.code` values from `api-spec.md`, and persisted state. Ownership
+  and idempotency live here because they are server responsibilities.
+- **UI component** — React Testing Library against a mocked API boundary, asserting what a
+  user sees: field errors, busy states, empty versus no-results, removed attachments.
+- **UI style** — automated assertions that the Zen Green rules in `ui-spec.md` are actually
+  applied: tokens, required markers, message placement, button hierarchy, ARIA roles.
+- **Responsive** — Playwright at three viewports, asserting no horizontal page scroll and
+  no clipped or overlapping content, and capturing the screenshots Part 9 requires.
+- **End-to-end** — Playwright against the real stack, covering the journeys that only mean
+  something when every layer participates.
+
+Two rules apply throughout. Ownership is never asserted only in the UI, because the UI is
+not what enforces it. And a mocked API boundary is mocked per endpoint, never as a blanket
+`fetch` stub — a blanket mock was the defect found in the peer's Lab 1 PR #8 and it makes
+a suite that cannot fail.
+
+**Infrastructure dependency.** The unit, API, UI and style suites run under the existing
+Vitest configuration, whose `tests/**` globs already match the `tests/lab-02/` paths below,
+so they need no configuration change. The Playwright rows do not yet have a runner: the
+repository has no Playwright dependency, no configuration and no `e2e/` directory. Issue
+[#27](https://github.com/Nuggetkub/toktickit/issues/27) adds them, and the responsive and
+E2E rows below are not claimed runnable until it merges.
+
+---
+
+## 2. Planned Tests
+
+| ID | Level | AC | Scenario and expected result | Test file | Status |
+|---|---|---|---|---|---|
+| UNIT-01 | Unit | AC-04 | Ticket Number formats as `TKT-<YYYY>-<NNNNN>` with zero padding, and the sequence restarts per year. | `server/tests/lab-02/ticket-number.test.ts` | Planned |
+| UNIT-02 | Unit | AC-05 | Summary and Description are trimmed before validation; 5/120 and 20/4000 boundaries accept and reject correctly; whitespace alone fails. | `server/tests/lab-02/ticket-validation.test.ts` | Planned |
+| UNIT-03 | Unit | AC-14 | Attachment type is decided from file content, not extension; a `.png` holding a script is rejected. Exactly 5 MB is accepted and one byte more is rejected. | `server/tests/lab-02/attachment-rules.test.ts` | Planned |
+| UNIT-04 | Unit | AC-14 | The active-attachment count ignores rows with `removedAt` set, so removing one frees a slot. | `server/tests/lab-02/attachment-rules.test.ts` | Planned |
+| UNIT-05 | Unit | AC-15 | Removal reason is trimmed and bounded to 5–250 characters. | `server/tests/lab-02/attachment-rules.test.ts` | Planned |
+| UNIT-06 | Unit | AC-09 | Query parsing accepts only the whitelisted sort fields, sort orders and page sizes, requires `page` ≥ 1, and reports each rejection as a field error. | `server/tests/lab-02/ticket-query.test.ts` | Planned |
+| API-01 | API | AC-01 | Categories, related systems and requesters return active rows only; the inactive requester never appears. | `server/tests/lab-02/reference.api.test.ts` | Planned |
+| API-02 | API | AC-04 | A valid create returns `201` with a `TKT-` number, `NEW`, a server `ticketDate`, and the `requesterId` taken from `X-Dev-Requester-Id` rather than the body. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-03 | API | AC-05 | Each broken field rule returns `400 VALIDATION_FAILED` with that field named in `fieldErrors`, and no ticket is persisted. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-04 | API | AC-06 | Replaying an `Idempotency-Key` with an identical payload returns `200` and the original ticket with no duplicate row; replaying it with a changed payload returns `409 IDEMPOTENCY_KEY_CONFLICT` and creates nothing. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-05 | API | AC-12 | A missing, malformed, or inactive `X-Dev-Requester-Id` returns `401 REQUESTER_CONTEXT_REQUIRED` on every requester-scoped route. | `server/tests/lab-02/requester-context.api.test.ts` | Planned |
+| API-06 | API | AC-08 | The list is scoped to the header's requester: A's tickets are returned for A and are absent for B, with no query parameter involved. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-07 | API | AC-09 | Search, each filter, sorting and paging return the correct subset with correct `page`, `pageSize`, `totalItems` and `totalPages`; a page past the end returns an empty array with `200`. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-08 | API | AC-10 | Sorting by `requestedPriority` ascending returns `LOW`, `MEDIUM`, `HIGH`, `URGENT` in severity order, not alphabetical order. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-09 | API | AC-09 | An unknown `sortBy`, an unknown `sortOrder`, a `pageSize` outside {10, 25, 50}, a `page` below 1, and an unrecognised priority each return `400` rather than being ignored. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-10 | API | AC-12 | An owned ticket returns `200`; a ticket owned by another requester returns `404 TICKET_NOT_FOUND`, identical to the response for a nonexistent id. | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
+| API-11 | API | AC-13 | A permitted file under the ceiling returns `201` with active metadata and a stored key that is not derived from the original filename. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-12 | API | AC-14 | Unsupported type returns `415`; oversize returns `413`; a sixth active file returns `409 ATTACHMENT_LIMIT_REACHED`; upload to another requester's ticket returns `404`. No metadata row is written in any case. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-13 | API | AC-15 | Soft removal returns `200` with reason, timestamp and remover; metadata still lists the attachment; a later download returns `404`; a second removal returns `409 ATTACHMENT_ALREADY_REMOVED` without overwriting the first reason. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-14 | API | AC-13 | Downloading an active attachment returns `200`, the recorded MIME type, and a `Content-Disposition` filename that is sanitised. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| UI-01 | UI | AC-01 | The selector lists active requesters only, states that it is a testing mechanism and not a login, and renders loading, empty and failure states. | `client/tests/lab-02/RequesterSelector.test.tsx` | Planned |
+| UI-02 | UI | AC-02 | Opening a requester-scoped route with nothing selected renders the selector, and no ticket data is requested. | `client/tests/lab-02/RequesterRouteGuard.test.tsx` | Planned |
+| UI-03 | UI | AC-03 | Create Ticket loads categories and related systems from the API and shows the selected requester as a read-only field. | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-04 | UI | AC-05 | Invalid input renders a message beneath each offending field, the submit stays disabled while busy, and entered values survive the failed attempt. | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-05 | UI | AC-04 | A successful create renders the returned Ticket Number and Ticket Date, and offers the next action. | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-06 | UI | AC-07 | An API failure renders a safe message with no raw network text, and every field value is preserved for retry. | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-07 | UI | AC-08 | Changing requester clears filters and paging and reloads the list for the new context. | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-08 | UI | AC-09 | Search, filters, sort and pagination controls drive the request and render the returned metadata, including page and total counts. | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-09 | UI | AC-11 | Owning no tickets and matching no tickets render different messages and different recovery actions. | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-10 | UI | AC-15 | Detail renders every field read-only, shows a removed attachment as retained metadata with a Removed badge, and offers no working download for it. | `client/tests/lab-02/TicketDetail.test.tsx` | Planned |
+| UI-11 | UI | AC-14 | A rejected file is named in the error together with its reason, and other selected files are unaffected. | `client/tests/lab-02/TicketDetail.test.tsx` | Planned |
+| UI-12 | UI | AC-07 | The API client converts a thrown `TypeError: Failed to fetch` into a human message before it reaches a component. | `client/tests/lab-02/apiClient.test.ts` | Planned |
+| STYLE-01 | UI style | AC-16 | Zen Green tokens are applied; required fields carry an asterisk; validation messages render beneath their field; read-only and editable fields are visually distinct; button variants and busy/disabled states are correct; `role="status"` and `role="alert"` are used as specified. | `client/tests/lab-02/ZenGreen.styles.test.tsx` | Planned |
+| RESP-01 | Responsive | AC-16 | Create Ticket, My Tickets and Ticket Detail at 1440×900, 834×1112 and 390×844: no horizontal page scroll, no clipped labels, no overlapping messages. Screenshots are written to `artifacts/lab-02/screenshots/`. | `e2e/lab-02/responsive.spec.ts` | Planned |
+| E2E-01 | E2E | AC-04, AC-08 | Select a requester, create a ticket, see its official number, then find that number in My Tickets. | `e2e/lab-02/create-and-find.spec.ts` | Planned |
+| E2E-02 | E2E | AC-08, AC-12 | Switch requester and confirm the first requester's tickets disappear; then open the first requester's ticket URL directly and confirm it is refused. | `e2e/lab-02/ownership.spec.ts` | Planned |
+| E2E-03 | E2E | AC-13, AC-15 | Upload a permitted attachment, download it, soft-remove it with a reason, and confirm the download is then blocked while the metadata remains. | `e2e/lab-02/attachments.spec.ts` | Planned |
+
+---
+
+## 3. Acceptance-Criterion Traceability
+
+Every acceptance criterion in `specification.md` §9 maps to at least one planned test.
+
+| AC | Planned tests |
+|---|---|
+| AC-01 Selector lists active requesters only | API-01, UI-01 |
+| AC-02 Unselected visitor sees the selector | UI-02 |
+| AC-03 Create Ticket loads reference data | UI-03 |
+| AC-04 Valid create saves one ticket with an official number | UNIT-01, API-02, UI-05, E2E-01 |
+| AC-05 Invalid create shows field errors and saves nothing | UNIT-02, API-03, UI-04 |
+| AC-06 Idempotent retry creates no duplicate | API-04 |
+| AC-07 Backend failure is safe and preserves input | UI-06, UI-12 |
+| AC-08 Tickets are scoped to the selected requester | API-06, UI-07, E2E-01, E2E-02 |
+| AC-09 Search, filter, sort, page and metadata are correct | UNIT-06, API-07, API-09, UI-08 |
+| AC-10 Priority sorts by severity | API-08 |
+| AC-11 Empty and no-results are distinct | UI-09 |
+| AC-12 Cross-requester access is refused as not found | API-05, API-10, E2E-02 |
+| AC-13 Permitted upload and download work | API-11, API-14, E2E-03 |
+| AC-14 Invalid, oversize and excess uploads are refused | UNIT-03, UNIT-04, API-12, UI-11 |
+| AC-15 Soft removal retains metadata and blocks download | UNIT-05, API-13, UI-10, E2E-03 |
+| AC-16 Three viewports render without clipping or overflow | STYLE-01, RESP-01 |
+
+---
+
+## 4. Responsive and Visual Checklist
+
+Checked at each viewport for Create Ticket, My Tickets and Ticket Detail:
+
+| Viewport | Width used | Required behaviour |
+|---|---|---|
+| Desktop | 1440×900 | Multi-column layout, content centred with a sensible maximum width. |
+| Tablet | 834×1112 | Two columns where practical; Summary and Description keep useful width. |
+| Mobile | 390×844 | Fields stack; touch targets stay usable; the table becomes cards; no page-level horizontal scroll. |
+
+- [ ] No clipped labels at any width
+- [ ] No overlapping validation messages
+- [ ] No hidden or unreachable buttons
+- [ ] Attachment filenames remain readable, truncating with an accessible full value
+- [ ] Required markers and field errors stay beside their field
+- [ ] Read-only fields remain visually distinct from editable fields
+- [ ] Loading, empty, no-results, success, error, busy and removed-attachment states all visible
+- [ ] Zen Green tokens consistent across all three screens
+- [ ] Priority and status badges legible without relying on colour alone
+
+Screenshots are stored under `artifacts/lab-02/screenshots/{create-ticket,my-tickets,ticket-detail}/`.
+
+---
+
+## 5. Commands
+
+```bash
+# unit + API
+cd server && npm test
+
+# UI component + UI style
+cd client && npm test
+
+# responsive + E2E (available after issue #27)
+npx playwright test e2e/lab-02
+```
+
+---
+
+## 6. Final Results
+
+*Implementation has not started.* This section will carry the real terminal output for the
+unit, API and UI suites captured from `main` after the release merge, together with the
+Playwright run and the responsive screenshots. Test counts and file paths will be filled in
+from that run, not from a feature branch and not from memory.
+
+---
+
+## 7. Known Limitations and Deferred Tests
+
+- **Authentication is not tested, because it does not exist.** The `X-Dev-Requester-Id`
+  header is forgeable by design. What *is* tested is that the server enforces ownership
+  against whatever identity that header supplies (API-05, API-10), which is the part that
+  survives into Lab 3 when the header is replaced by a real identity.
+- **IT Staff workflow, comments, internal notes, actions taken and post-`NEW` status
+  transitions have no tests**, because they are out of scope for this sprint.
+- **Storage durability is not tested.** Attachment bytes are written to the server
+  filesystem; tests assert metadata, ownership and the download guard rather than disk
+  behaviour.
+- **The responsive and E2E rows depend on issue #27** for their runner and are marked
+  `Planned` until that infrastructure exists.

--- a/docs/lab-02/ui-spec.md
+++ b/docs/lab-02/ui-spec.md
@@ -1,0 +1,269 @@
+# Lab 2 Zen Green UI Specification
+
+**Status:** Draft for peer review
+**Scope:** Development Requester Selection, Create Ticket, My Tickets, Requester Ticket
+Detail, and the Attachment components used by the last of these.
+
+Lab 2 establishes the presentation rules that later labs reuse. Anything defined here is
+built once as a shared component and consumed, not re-implemented per screen.
+
+---
+
+## 1. Design Principles
+
+The interface should feel calm and unhurried — a person filing a support ticket is usually
+already annoyed. Three rules follow from that:
+
+1. **State is always stated.** Loading, empty, no-results, submitting, success and failure
+   each say what is happening in words. A spinner alone is not a state.
+2. **Nothing is communicated by colour alone.** Every badge, error and status carries text
+   or an icon as well, which is also what makes the interface usable to someone who cannot
+   distinguish the greens from the greys.
+3. **The user's work is never lost.** A failed request leaves the form populated, and a
+   destructive action asks first.
+
+---
+
+## 2. Zen Green Tokens
+
+| Token | Value | Use |
+|---|---|---|
+| `--zen-primary` | `#006B3C` | Application header, primary buttons, strong emphasis |
+| `--zen-secondary` | `#0B7A46` | Active navigation, links, focus accents, hover states |
+| `--zen-pale` | `#EAF6EF` | Selected rows, success panels, subtle section emphasis |
+| `--zen-page` | `#F5F7F6` | Page background |
+| `--zen-surface` | `#FFFFFF` | Cards, forms, table surfaces |
+| `--zen-text` | `#12241C` | Body text — dark charcoal-green, deliberately not pure black |
+| `--zen-text-muted` | `#4A5A52` | Helper text, table secondary columns, metadata |
+| `--zen-border` | `#D6DFDA` | Field and card borders |
+| `--zen-readonly` | `#EFF2F0` | Read-only field background |
+| `--zen-error` | `#A32020` | Error text, invalid field border |
+| `--zen-warning` | `#B26A00` | Amber warning callout or badge |
+| `--zen-success` | `#006B3C` | Success confirmation, always paired with text |
+
+Warning colour is reserved for warnings. It is never used as decoration.
+
+### Typography and spacing
+
+- One font stack throughout; body text 16 px, never below 14 px for anything a user must
+  read.
+- Spacing uses a 4 px scale (4, 8, 12, 16, 24, 32). Fields within a group are separated by
+  16 px, groups by 24 px.
+- Cards use a 1 px `--zen-border`, an 8 px radius, and a restrained shadow — no heavy
+  elevation.
+
+---
+
+## 3. Control States
+
+| Element | Rule |
+|---|---|
+| Label | Above its control, always visible. Placeholder text is never a substitute for a label. |
+| Required field | Red asterisk after the label, plus `aria-required`. |
+| Editable field | `--zen-surface` background, `--zen-border` border. |
+| Read-only field | `--zen-readonly` background, no border emphasis, not focusable as an input. Clearly distinct from editable at a glance. |
+| Invalid field | `--zen-error` border, message immediately **below** the field, `aria-describedby` pointing at it. Never a single lumped error at the top of the form. |
+| Focus | Visible `--zen-secondary` focus ring on every interactive element, never removed. |
+| Disabled | Reduced contrast, `aria-disabled`, and not activatable. |
+| Busy button | Text changes to the present participle — "Creating ticket…" — and the button is disabled for the duration. |
+
+### Button hierarchy
+
+| Variant | Use | Appearance |
+|---|---|---|
+| Primary | The one main action on a screen | Solid `--zen-primary`, white text |
+| Secondary | Supporting action | Outlined, `--zen-primary` text |
+| Tertiary | Low-emphasis action such as Clear filters | Text only, underlined on hover |
+| Destructive | Attachment removal | Outlined `--zen-error`, requires confirmation |
+
+Every button carries visible text. Icons may support text but never replace it, and any
+icon-only control has an accessible name and a tooltip.
+
+### Announcements
+
+- `role="status"` for loading, submitting and success — polite, does not interrupt.
+- `role="alert"` for failures that need action — assertive.
+
+---
+
+## 4. Application Shell
+
+The header carries the TokTickIT identity, primary navigation (My Tickets, Create Ticket),
+the selected Requester's name, and a Change Requester action. The active route is indicated
+by both colour and an underline, so the indication survives a colour-blind reading.
+
+Change Requester returns to the selector and clears requester-scoped state — list filters,
+paging and any cached ticket — before the replacement context loads.
+
+Below 768 px the navigation stays reachable without horizontal scrolling: it collapses to a
+labelled menu, and the selected Requester's name remains visible in the header.
+
+---
+
+## 5. Development Requester Selection
+
+A single centred card containing the TokTickIT title, a short explanation, a dropdown of
+active Requesters, and a Continue button.
+
+**Required copy:** "Select a Development Requester to test requester-specific ticket
+behaviour. This is not a login screen and provides no security."
+
+| State | Presentation |
+|---|---|
+| Loading | Dropdown disabled, `role="status"` message "Loading requesters…" |
+| Ready | Active requesters listed by name with e-mail as secondary text; Continue enabled once a choice is made |
+| Empty | "No active Development Requesters are available." Continue disabled |
+| Failure | Safe retry message in `role="alert"`; no raw network text |
+
+The dropdown and Continue are keyboard reachable in that order, with a visible focus ring.
+
+---
+
+## 6. Create Ticket
+
+### Layout
+
+A centred card, maximum width around 880 px. Content order:
+
+1. **System-assigned block** — Ticket Number and Ticket Date, side by side. Both are
+   read-only. Before submission they show placeholder text explaining that the backend
+   assigns them when the ticket is saved; after a successful save they show the real
+   values.
+2. **Requester** — read-only, populated from the selected context.
+3. **Classification** — Category and Related System, side by side on desktop, stacked on
+   mobile.
+4. **Ticket Summary** — full width, single line.
+5. **Requested Priority** — a four-option control, labelled with words rather than colour.
+6. **Description** — full width textarea, resizable vertically without breaking the layout.
+7. **Attachments** — the file selection area, with the permitted types and the 5 MB and
+   five-file limits stated up front rather than discovered on rejection.
+8. **Actions** — Submit Ticket as the only primary button, Cancel as secondary.
+
+### States
+
+| State | Presentation |
+|---|---|
+| Initial | Empty form, reference data loaded, submit enabled |
+| Loading reference data | Category and Related System disabled with `role="status"` |
+| Validation failure | Message under each offending field; focus moves to the first invalid field; entered values retained |
+| Submitting | Submit shows "Creating ticket…" and is disabled |
+| Success | `--zen-pale` panel stating the ticket was created, showing the Ticket Number and Ticket Date, with links to view the ticket or create another |
+| API failure | `role="alert"` with a safe message; **every entered value is preserved**; retry available |
+| Invalid attachment | The rejected file is named alongside its reason — type, size, or the five-file limit — and other selected files are unaffected |
+
+---
+
+## 7. My Tickets
+
+### Toolbar
+
+Search field, Category filter, Related System filter, Requested Priority filter, Sort
+control, Clear filters (tertiary), and Create Ticket (primary). The toolbar wraps to
+multiple rows rather than scrolling horizontally.
+
+There is **no Current Status filter in Lab 2** — every ticket is `NEW`, so the control
+could never change the result set. It arrives in Lab 3 with the statuses that make it
+meaningful.
+
+### List
+
+Desktop is a table: Ticket Number, Summary, Category, Related System, Requested Priority,
+Ticket Date. Ticket Number and Summary open the detail screen. Tablet may drop Related
+System. Mobile becomes a card per ticket carrying Ticket Number, Summary, Priority badge
+and Ticket Date, with a clear View detail action.
+
+### States
+
+| State | Presentation |
+|---|---|
+| Loading | Skeleton rows or a `role="status"` message; the toolbar stays usable |
+| Empty | "You have not created any tickets yet," with a Create Ticket action |
+| No results | "No tickets match your search or filters," with a Clear filters action |
+| Failure | `role="alert"` with a safe message and a retry |
+
+Empty and no-results are deliberately different messages with different recovery actions —
+telling someone to clear filters they never set is confusing.
+
+### Pagination
+
+Shows the current page, the total pages and the total result count in words — "Showing
+1–10 of 24 tickets". Previous and Next are visibly disabled at the ends rather than
+removed.
+
+---
+
+## 8. Requester Ticket Detail and Attachments
+
+All ticket fields are read-only: Ticket Number, Ticket Date, Requester, Category, Related
+System, Summary, Requested Priority, Current Status, Description. They use the read-only
+field treatment so the screen never invites editing that Lab 2 does not support.
+
+### Attachment section
+
+Visually separate, listing for each file: original filename, type, size, upload time and
+state.
+
+| Attachment state | Presentation |
+|---|---|
+| Active | Download (secondary) and Remove (destructive) actions |
+| Uploading | Progress or busy indication, `role="status"` |
+| Invalid | Named with its rejection reason; not added to the list |
+| Removed | Retained metadata, a Removed badge, the removal reason and date shown; **no working download** — the control is absent or disabled with an explanation |
+
+Removal opens a confirmation requiring a typed reason of 5–250 characters. The confirm
+button is destructive and disabled until the reason is valid.
+
+Upload errors appear beside the attachment section, not at the top of the page, and name
+the file they concern.
+
+---
+
+## 9. Responsive Rules
+
+| Viewport | Behaviour |
+|---|---|
+| Desktop ≥ 992 px | Multi-column form and table layout; content centred with a maximum width |
+| Tablet 768–991 px | Two columns where practical; Summary and Description keep useful width; secondary table columns may drop |
+| Mobile < 768 px | Fields stack; touch targets at least 44 px; table becomes cards; **no page-level horizontal scrolling** |
+| All sizes | No clipped labels, no overlapping messages, no hidden buttons, no unreadable attachment names |
+
+Where a wide element genuinely cannot shrink, it scrolls inside its own container — the
+page itself never scrolls sideways.
+
+---
+
+## 10. Accessibility
+
+- Every control has a visible label; icon-only controls carry an accessible name and
+  tooltip.
+- Keyboard order follows visual order; focus indicators are never suppressed.
+- Colour is never the only carrier of meaning — priority and status badges include text.
+- Validation messages are associated with their field via `aria-describedby`, and invalid
+  fields set `aria-invalid`.
+- Body text contrast meets WCAG AA against its background; `--zen-text` on `--zen-surface`
+  and white on `--zen-primary` both satisfy it.
+
+---
+
+## 11. Visual Inspection Checklist
+
+Completed against the real running screens at all three viewports, not from memory:
+
+- [ ] Zen Green tokens applied consistently across all four screens
+- [ ] Read-only fields clearly distinct from editable fields
+- [ ] Required markers present; validation messages sit beneath their own field
+- [ ] Button hierarchy correct; only one primary action per screen
+- [ ] Busy and disabled states visible and non-activatable
+- [ ] Loading, empty, no-results, success and failure states all reachable and legible
+- [ ] Removed attachments show retained metadata with no working download
+- [ ] Priority badges readable without relying on colour
+- [ ] No clipping, overlap, or page-level horizontal scrolling at any viewport
+- [ ] Keyboard focus visible throughout, tab order sensible
+
+### Screenshot paths
+
+```
+artifacts/lab-02/screenshots/create-ticket/{desktop,tablet,mobile}.png
+artifacts/lab-02/screenshots/my-tickets/{desktop,tablet,mobile}.png
+artifacts/lab-02/screenshots/ticket-detail/{desktop,tablet,mobile}.png
+```


### PR DESCRIPTION
## Summary

Adds the Lab 2 engineering contract before any implementation begins, per Spec-DD. Five
documents under `docs/lab-02/`:

- **`specification.md`** — all eleven required sections. FR-01…FR-12, BR-01…BR-45,
  AC-01…AC-16 in Given/when/then form, the data design with justified constraints and
  indexes, the Definition of Done, and twelve recorded decisions.
- **`api-spec.md`** — all ten required capabilities with paths, parameters, payloads,
  responses, status codes and error codes.
- **`tests.md`** — 36 planned tests across unit, API, UI component, UI style, responsive
  and E2E. Every acceptance criterion traces to at least one test, and every test names a
  real file path.
- **`ui-spec.md`** — Zen Green tokens, control and button states, the four screen layouts,
  the three breakpoints, accessibility rules, and the visual inspection checklist.
- **`ai-use.md`** — the prompts actually used so far, with the reflection.

## Decisions worth a reviewer's attention

Recorded in `specification.md` §11:

- **Identity travels in an `X-Dev-Requester-Id` header** rather than as a query parameter
  or body field on every endpoint (D-01). It keeps identity out of the resource payload,
  gives ownership checks a single middleware to live in, and makes Lab 3 a substitution at
  one seam instead of a change to every route signature.
- **Every invalid client input returns `400` with `fieldErrors`; `422` is unused** (D-03).
  One rule is easier to implement consistently and to test than a malformed-versus-invalid
  split whose boundary is genuinely ambiguous for a JSON body.
- **Cross-requester access returns `404`, never `403`** (D-04), so the response does not
  confirm that another requester's resource exists.
- **Current Status is not offered as a My Tickets filter** (D-07). Every Lab 2 ticket is
  `NEW` and the seed creates no tickets, so the control could never change a result set.
  Part 7 filter evidence uses Category, Related System and Requested Priority.
- **Requested Priority is a Postgres enum declared in severity order** (D-08), so ascending
  sort runs `LOW` → `MEDIUM` → `HIGH` → `URGENT` rather than alphabetically.
- **The seed creates no tickets** (D-11), so every ticket in the evidence screenshots came
  through the application.

## Validation

Documentation only — no application code, schema, migration or test execution is included
in this pull request.

- Confirmed all eleven `specification.md` sections required by the labsheet are present.
- Confirmed each of the sixteen acceptance criteria appears in the `tests.md` traceability
  table with at least one planned test.
- Confirmed the ten required API capabilities each map to an endpoint (`api-spec.md` §6).
- Confirmed the fixed labsheet constraints are carried rather than re-decided: the palette,
  the 5 MB and five-active attachment limits, the permitted types, the four categories, and
  the three breakpoints.

## Review focus

1. Are the business rules and acceptance criteria internally consistent, and does anything
   in `api-spec.md` contradict `specification.md`?
2. Is the header-based identity seam (D-01) a sound call, or does putting `requesterId` in
   the payload have an advantage I have missed?
3. Are the validation bounds in BR-12 and BR-13 defensible, and is the single-`400` rule
   (D-03) going to be awkward anywhere?
4. Does any excluded item — Lab 3 authentication, IT Staff workflow, comments, post-`NEW`
   status changes — leak back into the scope anywhere?

## Note on independence

I reviewed your Lab 2 contract in `Earth2509/toktickit` PR #12 before writing this, so I
had read yours closely. The decisions here are reasoned from the labsheet rather than
adapted from yours, and where we necessarily agree it is because the labsheet fixes the
constraint. The differences are recorded in `specification.md` §11 D-12.

Relates to #17
