### PR TITLE
Issue 19: Lab 2 data model, idempotent seed, and reference APIs

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -189,6 +189,21 @@ Verified after the change: `lab2_test` holds 4 categories, 7 related systems and
 requesters, while `public` still holds 4 active categories, 7 active related systems and
 4 active requesters — untouched by the run.
 
+**Reset, added in the second review round.** @Earth2509 then pointed out that
+`migrate deploy` applies pending migrations but never clears data, so `lab2_test` carried
+rows from one run to the next — and `seed.test.ts`'s "no tickets" assertion would start
+depending on the previous run as soon as a suite began creating them. `global-setup.ts` now
+drops and recreates the schema before migrating, with a guard that refuses to run if the
+target schema is ever `public`. Verified by planting a stray ticket in `lab2_test` by hand
+and confirming the next run cleared it.
+
+He also reported that `npm run build` fails on a clean install until `prisma generate` is
+run. **That did not reproduce here** — a fresh clone plus `npm ci` produced a client
+containing all four new models, because `@prisma/client` runs `prisma generate` from its own
+postinstall hook. An explicit `"postinstall": "prisma generate"` was added to
+`server/package.json` regardless: depending on a transitive dependency's lifecycle hook is
+fragile, and `npm ci --ignore-scripts` or a stale `node_modules` would break it.
+
 **Honest note on the race.** It is real by construction, but it was *not* reproduced:
 six runs with parallelism forced back on all passed. The mutate-assert-restore window is
 only a few milliseconds wide. The fix stands regardless — a suite that fails one run in a

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -169,8 +169,31 @@ Run on `feature/19-data-and-reference-apis` on 2026-08-29, before peer review:
   (4 active, 1 inactive), 0 tickets. Row counts read directly out of PostgreSQL after the
   second run were identical, and `tests/lab-02/seed.test.ts` now asserts this in CI rather
   than relying on someone remembering to run it twice.
-- `cd server && npm test` — 5 files, **16 tests passed**.
+- `cd server && npm test` — 5 files, **17 tests passed**.
 - `cd server && npm run build` — passed.
+
+**Test isolation, added in review.** @Earth2509 pointed out on PR #31 that two suites
+deactivate a seeded row to prove active-only filtering, and that Vitest runs test files in
+parallel by default — so `categories.test.ts`, which asserts four active categories, could
+run while one of them was switched off, and a suite failing before its cleanup would leave
+the shared development database wrong. Both are correct. Three changes:
+
+1. `tests/global-setup.ts` creates, migrates (`prisma migrate deploy`) and seeds an
+   isolated `lab2_test` PostgreSQL schema once per run; `tests/setup-env.ts` points each
+   worker's client at it. **The suite no longer touches the development database at all.**
+2. `fileParallelism: false` in `vitest.config.ts`. An isolated schema stops the tests
+   corrupting development data; only serial execution stops them corrupting each other.
+3. The restore in `finally` is kept as defence in depth.
+
+Verified after the change: `lab2_test` holds 4 categories, 7 related systems and 5
+requesters, while `public` still holds 4 active categories, 7 active related systems and
+4 active requesters — untouched by the run.
+
+**Honest note on the race.** It is real by construction, but it was *not* reproduced:
+six runs with parallelism forced back on all passed. The mutate-assert-restore window is
+only a few milliseconds wide. The fix stands regardless — a suite that fails one run in a
+hundred is worse than one that fails every time, because the first gets re-run until it
+passes and the second gets fixed.
 
 **One contract change to note.** `GET /api/categories` previously returned rows in id
 order, which was the Lab 1 contract. `api-spec.md` §2 — written and merged in Issue #17,

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -51,7 +51,9 @@ E2E rows below are not claimed runnable until it merges.
 | UNIT-04 | Unit | AC-14 | The active-attachment count ignores rows with `removedAt` set, so removing one frees a slot. | `server/tests/lab-02/attachment-rules.test.ts` | Planned |
 | UNIT-05 | Unit | AC-15 | Removal reason is trimmed and bounded to 5–250 characters. | `server/tests/lab-02/attachment-rules.test.ts` | Planned |
 | UNIT-06 | Unit | AC-09 | Query parsing accepts only the whitelisted sort fields, sort orders and page sizes, requires `page` ≥ 1, and reports each rejection as a field error. | `server/tests/lab-02/ticket-query.test.ts` | Planned |
-| API-01 | API | AC-01 | Categories, related systems and requesters return active rows only; the inactive requester never appears. | `server/tests/lab-02/reference.api.test.ts` | Planned |
+| API-01 | API | AC-01 | Categories, related systems and requesters return active rows only, ordered by name and exposing only the contracted fields; a deactivated category disappears; the inactive requester never appears. | `server/tests/lab-02/reference.api.test.ts` | Planned |
+| API-15 | API | AC-01 | With the database unreachable, all three reference endpoints return `503 DEPENDENCY_UNAVAILABLE` in the documented envelope and leak no cause, SQL or stack trace. | `server/tests/lab-02/reference-failure.api.test.ts` | Planned |
+| UNIT-07 | Unit | AC-01 | The seed is idempotent: a second run creates no duplicates, restores a requester deactivated by hand, and seeds no tickets. | `server/tests/lab-02/seed.test.ts` | Planned |
 | API-02 | API | AC-04 | A valid create returns `201` with a `TKT-` number, `NEW`, a server `ticketDate`, and the `requesterId` taken from `X-Dev-Requester-Id` rather than the body. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-03 | API | AC-05 | Each broken field rule returns `400 VALIDATION_FAILED` with that field named in `fieldErrors`, and no ticket is persisted. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-04 | API | AC-06 | Replaying an `Idempotency-Key` with an identical payload returns `200` and the original ticket with no duplicate row; replaying it with a changed payload returns `409 IDEMPOTENCY_KEY_CONFLICT` and creates nothing. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
@@ -91,7 +93,7 @@ Every acceptance criterion in `specification.md` §9 maps to at least one planne
 
 | AC | Planned tests |
 |---|---|
-| AC-01 Selector lists active requesters only | API-01, UI-01 |
+| AC-01 Selector lists active requesters only | UNIT-07, API-01, API-15, UI-01 |
 | AC-02 Unselected visitor sees the selector | UI-02 |
 | AC-03 Create Ticket loads reference data | UI-03 |
 | AC-04 Valid create saves one ticket with an official number | UNIT-01, API-02, UI-05, E2E-01 |
@@ -155,6 +157,27 @@ npx playwright test e2e/lab-02
 unit, API and UI suites captured from `main` after the release merge, together with the
 Playwright run and the responsive screenshots. Test counts and file paths will be filled in
 from that run, not from a feature branch and not from memory.
+
+### Issue #19 feature-branch verification
+
+Run on `feature/19-data-and-reference-apis` on 2026-08-29, before peer review:
+
+- `npx prisma migrate dev --name lab2_data_model` — the migration was **generated and
+  applied by Prisma against the real database**, not hand-written. `migration_lock.toml`
+  and `20260829081823_lab2_data_model/migration.sql` are both committed.
+- `npm run prisma:seed`, run **twice** — 4 categories, 7 related systems, 5 requesters
+  (4 active, 1 inactive), 0 tickets. Row counts read directly out of PostgreSQL after the
+  second run were identical, and `tests/lab-02/seed.test.ts` now asserts this in CI rather
+  than relying on someone remembering to run it twice.
+- `cd server && npm test` — 5 files, **16 tests passed**.
+- `cd server && npm run build` — passed.
+
+**One contract change to note.** `GET /api/categories` previously returned rows in id
+order, which was the Lab 1 contract. `api-spec.md` §2 — written and merged in Issue #17,
+before this implementation — specifies that all three reference endpoints order by name so
+the dropdowns read alphabetically. The endpoint follows the newer contract, and
+`tests/lab-01/categories.test.ts` was updated to match, with the reason recorded in the
+file itself. Only the ordering assertions changed; the `{ id, name }` shape did not.
 
 ### Issue #18 feature-branch verification
 

--- a/server/package.json
+++ b/server/package.json
@@ -10,9 +10,12 @@
     "start": "node dist/index.js",
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "tsx prisma/seed.ts",
-    "test": "vitest run"
+    "test": "vitest run",
+    "postinstall": "prisma generate"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",

--- a/server/prisma/migrations/20260829081823_lab2_data_model/migration.sql
+++ b/server/prisma/migrations/20260829081823_lab2_data_model/migration.sql
@@ -1,0 +1,107 @@
+-- CreateEnum
+CREATE TYPE "RequestedPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Requester" (
+    "id" SERIAL NOT NULL,
+    "fullName" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Requester_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "RequestedPriority" NOT NULL,
+    "currentStatus" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "idempotencyKey" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removedByRequesterId" INTEGER,
+    "removalReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Requester_email_key" ON "Requester"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_idempotencyKey_key" ON "Ticket"("idempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_createdAt_idx" ON "Ticket"("requesterId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "Ticket_categoryId_idx" ON "Ticket"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_relatedSystemId_idx" ON "Ticket"("relatedSystemId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attachment_storageKey_key" ON "Attachment"("storageKey");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_removedAt_idx" ON "Attachment"("ticketId", "removedAt");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "Requester"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_removedByRequesterId_fkey" FOREIGN KEY ("removedByRequesterId") REFERENCES "Requester"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,5 +1,9 @@
 // Prisma schema — datasource and generator are pre-wired.
 // Your DATABASE_URL lives in server/.env (copy it from .env.example).
+//
+// The Lab 2 data design and the reasoning behind it are in
+// docs/lab-02/specification.md §7. Constraints and indexes are not decorative:
+// each one is justified there against the query that needs it.
 
 generator client {
   provider = "prisma-client-js"
@@ -10,10 +14,109 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// Declared in severity order so PostgreSQL sorts by severity rather than
+// alphabetically. Sorting a string column would give HIGH, LOW, MEDIUM, URGENT,
+// which is meaningless to a user (BR-25, decision D-08).
+enum RequestedPriority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+// Lab 2 has exactly one status. Lab 3 adds its remaining members without a data
+// migration (BR-03).
+enum TicketStatus {
+  NEW
+}
+
 // An IT request category. `name` is unique so the seed can upsert on it and
 // stay idempotent.
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+// The specific service, application or device a ticket concerns.
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tickets Ticket[]
+}
+
+// The person who owns tickets. In Lab 2 one of these is chosen through the
+// Development Requester selector, which is a testing mechanism and not
+// authentication (BR-05). In Lab 3 an authenticated identity resolves to this
+// same model, so ownership survives unchanged (BR-45).
+model Requester {
+  id        Int      @id @default(autoincrement())
+  fullName  String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tickets           Ticket[]
+  removedAttachments Attachment[] @relation("AttachmentRemovedBy")
+}
+
+model Ticket {
+  id              Int               @id @default(autoincrement())
+  ticketNumber    String            @unique
+  requesterId     Int
+  categoryId      Int
+  relatedSystemId Int
+  summary         String
+  description     String
+  requestedPriority RequestedPriority
+  currentStatus   TicketStatus      @default(NEW)
+  // Nullable because PostgreSQL permits many NULLs under a unique index, so a
+  // ticket created by any future path that has no key is unaffected (BR-19).
+  idempotencyKey  String?           @unique
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
+
+  requester     Requester     @relation(fields: [requesterId], references: [id])
+  category      Category      @relation(fields: [categoryId], references: [id])
+  relatedSystem RelatedSystem @relation(fields: [relatedSystemId], references: [id])
+  attachments   Attachment[]
+
+  // Every My Tickets query filters by requester and orders by date descending.
+  // This is the index that query exists for.
+  @@index([requesterId, createdAt(sort: Desc)])
+  @@index([categoryId])
+  @@index([relatedSystemId])
+}
+
+model Attachment {
+  id               Int       @id @default(autoincrement())
+  ticketId         Int
+  // Server-generated. The original filename is display metadata only and never
+  // builds a server path (BR-35).
+  storageKey       String    @unique
+  originalFilename String
+  mimeType         String
+  sizeBytes        Int
+  uploadedAt       DateTime  @default(now())
+
+  // Soft removal. Nullable columns rather than a boolean, so the row records
+  // when, by whom and why — see the justified decision in specification.md §7.
+  // `removedAt IS NULL` is the single indexable definition of "active".
+  removedAt            DateTime?
+  removedByRequesterId Int?
+  removalReason        String?
+
+  ticket    Ticket     @relation(fields: [ticketId], references: [id])
+  removedBy Requester? @relation("AttachmentRemovedBy", fields: [removedByRequesterId], references: [id])
+
+  // The five-active-attachment count (BR-33) is the hottest attachment query.
+  @@index([ticketId, removedAt])
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,32 +1,32 @@
 import { getPrisma } from "../src/prisma.js";
+import { seedReferenceData } from "../src/seed-data.js";
 
-// The four supported IT request categories, in the order they should appear.
-// Seeding sequentially (not in parallel) keeps autoincrement ids in this order
-// on a fresh database, which is what the categories test asserts.
-const CATEGORY_NAMES = [
-  "Account and Access",
-  "Hardware",
-  "Software",
-  "Network",
-];
+// Thin runner. The data and the upsert logic live in src/seed-data.ts so that
+// tests/lab-02/seed.test.ts can execute them directly and prove the seed is
+// idempotent, rather than relying on someone remembering to run it twice.
 
 async function main() {
   const prisma = getPrisma();
 
-  for (const name of CATEGORY_NAMES) {
-    // upsert on the unique name: re-running the seed updates nothing and
-    // creates nothing, so it never produces duplicates.
-    await prisma.category.upsert({
-      where: { name },
-      update: {},
-      create: { name },
-    });
+  await seedReferenceData(prisma);
+
+  const categories = await prisma.category.findMany({ orderBy: { id: "asc" } });
+  console.log(`Seeded ${categories.length} categories:`);
+  for (const category of categories) {
+    console.log(`  ${category.id}  ${category.name}`);
   }
 
-  const seeded = await prisma.category.findMany({ orderBy: { id: "asc" } });
-  console.log(`Seeded ${seeded.length} categories:`);
-  for (const category of seeded) {
-    console.log(`  ${category.id}  ${category.name}`);
+  const relatedSystems = await prisma.relatedSystem.findMany({ orderBy: { id: "asc" } });
+  console.log(`Seeded ${relatedSystems.length} related systems:`);
+  for (const relatedSystem of relatedSystems) {
+    console.log(`  ${relatedSystem.id}  ${relatedSystem.name}`);
+  }
+
+  const requesters = await prisma.requester.findMany({ orderBy: { id: "asc" } });
+  const active = requesters.filter((requester) => requester.isActive).length;
+  console.log(`Seeded ${requesters.length} requesters (${active} active, ${requesters.length - active} inactive):`);
+  for (const requester of requesters) {
+    console.log(`  ${requester.id}  ${requester.isActive ? "active  " : "inactive"}  ${requester.fullName}`);
   }
 }
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
 import { CLIENT_ORIGIN, SERVICE_NAME } from "./config.js";
+import { sendDependencyUnavailable } from "./errors.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -21,17 +22,54 @@ app.get("/api/health", (_req: Request, res: Response) => {
   res.status(200).json({ status: "ok", service: SERVICE_NAME });
 });
 
+// ---------------------------------------------------------------------------
+// Issue 19 — Lab 2 reference data (api-spec.md §2)
+//
+// These three are not requester-scoped and take no identity header: the
+// selector has to be able to load before a Requester has been chosen at all.
+//
+// All three return active rows only and are ordered by name, so the dropdowns
+// that consume them read alphabetically rather than in insertion order. An
+// empty array is a valid answer — the interface treats it as an empty state,
+// not as an error.
+// ---------------------------------------------------------------------------
+
 app.get("/api/categories", async (_req: Request, res: Response) => {
   try {
     const categories = await getPrisma().category.findMany({
+      where: { isActive: true },
       select: { id: true, name: true },
-      orderBy: { id: "asc" },
+      orderBy: { name: "asc" },
     });
     res.status(200).json(categories);
   } catch (err) {
-    // Log the real cause for us, but never leak it to the client.
-    console.error("GET /api/categories failed:", err);
-    res.status(500).json({ error: "Could not load categories." });
+    sendDependencyUnavailable(res, "GET /api/categories", err);
+  }
+});
+
+app.get("/api/related-systems", async (_req: Request, res: Response) => {
+  try {
+    const relatedSystems = await getPrisma().relatedSystem.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    });
+    res.status(200).json(relatedSystems);
+  } catch (err) {
+    sendDependencyUnavailable(res, "GET /api/related-systems", err);
+  }
+});
+
+app.get("/api/requesters", async (_req: Request, res: Response) => {
+  try {
+    const requesters = await getPrisma().requester.findMany({
+      where: { isActive: true },
+      select: { id: true, fullName: true, email: true },
+      orderBy: { fullName: "asc" },
+    });
+    res.status(200).json(requesters);
+  } catch (err) {
+    sendDependencyUnavailable(res, "GET /api/requesters", err);
   }
 });
 

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,0 +1,32 @@
+import type { Response } from "express";
+
+// Every error response in Lab 2 uses one shape (api-spec.md §1):
+//   { "error": { "code": string, "message": string, "fieldErrors"?: {...} } }
+// `code` is the stable identifier tests assert on; `message` is safe to display.
+export type ErrorCode =
+  | "VALIDATION_FAILED"
+  | "REQUESTER_CONTEXT_REQUIRED"
+  | "TICKET_NOT_FOUND"
+  | "REFERENCE_NOT_FOUND"
+  | "INTERNAL_ERROR"
+  | "DEPENDENCY_UNAVAILABLE";
+
+export function sendError(
+  res: Response,
+  status: number,
+  code: ErrorCode,
+  message: string,
+  fieldErrors?: Record<string, string>,
+): void {
+  res.status(status).json({ error: { code, message, ...(fieldErrors ? { fieldErrors } : {}) } });
+}
+
+/**
+ * The database or another dependency is unreachable. The real cause is logged
+ * for us and never sent to the client: a stack trace or a connection string in
+ * a response is exactly what BR-41 forbids.
+ */
+export function sendDependencyUnavailable(res: Response, context: string, cause: unknown): void {
+  console.error(`${context} failed:`, cause);
+  sendError(res, 503, "DEPENDENCY_UNAVAILABLE", "The service is temporarily unavailable. Please try again.");
+}

--- a/server/src/prisma.ts
+++ b/server/src/prisma.ts
@@ -6,6 +6,13 @@ import { PrismaClient } from "@prisma/client";
 let client: PrismaClient | null = null;
 
 export function getPrisma(): PrismaClient {
-  if (!client) client = new PrismaClient();
+  if (!client) {
+    // Prisma resolves DATABASE_URL from server/.env on its own. Passing it
+    // explicitly when it *is* present in the environment lets the test run
+    // redirect the client to an isolated schema (tests/setup-env.ts) without
+    // changing how the application behaves in development or production.
+    const url = process.env.DATABASE_URL;
+    client = url ? new PrismaClient({ datasourceUrl: url }) : new PrismaClient();
+  }
   return client;
 }

--- a/server/src/seed-data.ts
+++ b/server/src/seed-data.ts
@@ -1,0 +1,78 @@
+import type { PrismaClient } from "@prisma/client";
+
+// The Lab 2 reference data, and the function that applies it.
+//
+// This lives in src/ rather than inside prisma/seed.ts so that the seeding
+// logic can be imported and executed by a test. A seed whose idempotency is
+// only ever checked by a human running it twice is a seed whose idempotency
+// stops being true the moment someone edits it.
+
+// The four supported IT request categories, in the order they should appear.
+export const CATEGORY_NAMES = [
+  "Account and Access",
+  "Hardware",
+  "Software",
+  "Network",
+] as const;
+
+// The specific service, application or device a ticket concerns. The labsheet
+// asks for at least six.
+export const RELATED_SYSTEM_NAMES = [
+  "Email",
+  "Campus Wi-Fi",
+  "VPN",
+  "LEB2 App",
+  "Grade Submission App",
+  "Printer",
+  "Corporate Laptop",
+] as const;
+
+// Four active Development Requesters plus one inactive. The inactive row must
+// never reach the selector (BR-06), so it is test fixture as much as seed data.
+export const REQUESTERS = [
+  { fullName: "Nadia Rahman", email: "nadia.rahman@toktickit.local", isActive: true },
+  { fullName: "Somchai Pattana", email: "somchai.pattana@toktickit.local", isActive: true },
+  { fullName: "Marisa Chen", email: "marisa.chen@toktickit.local", isActive: true },
+  { fullName: "Tobias Lindqvist", email: "tobias.lindqvist@toktickit.local", isActive: true },
+  { fullName: "Priya Anand (retired account)", email: "priya.anand@toktickit.local", isActive: false },
+] as const;
+
+/**
+ * Applies the reference data. Every write is an upsert on a unique natural key,
+ * so running this twice creates nothing and changes nothing.
+ *
+ * Rows are seeded sequentially rather than in parallel: on a fresh database that
+ * keeps autoincrement ids in declaration order, which several tests rely on.
+ *
+ * No tickets are seeded, deliberately. Every ticket in the Part 6 and Part 7
+ * evidence must have been created through the application, or the screenshots
+ * prove nothing about the software (decision D-11).
+ */
+export async function seedReferenceData(prisma: PrismaClient): Promise<void> {
+  for (const name of CATEGORY_NAMES) {
+    await prisma.category.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+
+  for (const name of RELATED_SYSTEM_NAMES) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+
+  for (const requester of REQUESTERS) {
+    // `isActive` is in the update clause because it is the one field the seed
+    // must be able to correct: a requester flipped active by hand during
+    // testing has to return to its seeded state on the next run.
+    await prisma.requester.upsert({
+      where: { email: requester.email },
+      update: { fullName: requester.fullName, isActive: requester.isActive },
+      create: requester,
+    });
+  }
+}

--- a/server/tests/global-setup.ts
+++ b/server/tests/global-setup.ts
@@ -1,0 +1,29 @@
+import { execSync } from "node:child_process";
+import { PrismaClient } from "@prisma/client";
+import { seedReferenceData } from "../src/seed-data.js";
+import { TEST_SCHEMA, testDatabaseUrl } from "./test-database.js";
+
+// Runs once, before any worker starts: create the test schema, apply every
+// committed migration to it, and seed the reference data the suites expect.
+//
+// `migrate deploy` rather than `migrate dev` — deploy only applies what is
+// already committed, so the tests can never invent a migration that is missing
+// from the repository.
+export default async function setup(): Promise<void> {
+  const url = testDatabaseUrl();
+
+  execSync("npx prisma migrate deploy", {
+    cwd: process.cwd(),
+    env: { ...process.env, DATABASE_URL: url },
+    stdio: "pipe",
+  });
+
+  const prisma = new PrismaClient({ datasourceUrl: url });
+  try {
+    await seedReferenceData(prisma);
+  } finally {
+    await prisma.$disconnect();
+  }
+
+  console.log(`[test setup] schema "${TEST_SCHEMA}" migrated and seeded`);
+}

--- a/server/tests/global-setup.ts
+++ b/server/tests/global-setup.ts
@@ -1,16 +1,38 @@
 import { execSync } from "node:child_process";
 import { PrismaClient } from "@prisma/client";
 import { seedReferenceData } from "../src/seed-data.js";
-import { TEST_SCHEMA, testDatabaseUrl } from "./test-database.js";
+import { TEST_SCHEMA, baseDatabaseUrl, testDatabaseUrl } from "./test-database.js";
 
-// Runs once, before any worker starts: create the test schema, apply every
-// committed migration to it, and seed the reference data the suites expect.
+// Runs once, before any worker starts.
 //
-// `migrate deploy` rather than `migrate dev` — deploy only applies what is
-// already committed, so the tests can never invent a migration that is missing
-// from the repository.
+// The schema is dropped and recreated first, so every run begins from a known
+// empty state. `prisma migrate deploy` only applies migrations that have not
+// been applied yet — it does not clear data — so without the drop, rows created
+// by one run would survive into the next. That matters as soon as a suite
+// creates Tickets: seed.test.ts asserts there are none, and that assertion
+// would quietly start depending on what the previous run happened to leave
+// behind rather than on anything this run did.
+//
+// `migrate deploy` rather than `migrate dev`, so a test run can only ever apply
+// migrations that are already committed and can never invent one.
+
 export default async function setup(): Promise<void> {
+  // Guard: this function drops a schema. It must never be pointed at the
+  // development data by a bad edit to TEST_SCHEMA.
+  if (!TEST_SCHEMA || TEST_SCHEMA === "public") {
+    throw new Error(`Refusing to reset schema "${TEST_SCHEMA}" — the test schema must not be "public".`);
+  }
+
   const url = testDatabaseUrl();
+
+  // Connect outside the test schema to drop and recreate it.
+  const admin = new PrismaClient({ datasourceUrl: baseDatabaseUrl() });
+  try {
+    await admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${TEST_SCHEMA}" CASCADE`);
+    await admin.$executeRawUnsafe(`CREATE SCHEMA "${TEST_SCHEMA}"`);
+  } finally {
+    await admin.$disconnect();
+  }
 
   execSync("npx prisma migrate deploy", {
     cwd: process.cwd(),
@@ -25,5 +47,5 @@ export default async function setup(): Promise<void> {
     await prisma.$disconnect();
   }
 
-  console.log(`[test setup] schema "${TEST_SCHEMA}" migrated and seeded`);
+  console.log(`[test setup] schema "${TEST_SCHEMA}" reset, migrated and seeded`);
 }

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -4,23 +4,32 @@ import { app } from "../../src/app.js";
 
 // Requires the DB to be migrated and seeded first:
 //   npx prisma migrate dev  &&  npm run prisma:seed
-const SEEDED_NAMES = ["Account and Access", "Hardware", "Software", "Network"];
+//
+// UPDATED IN LAB 2 (Issue #19). This test previously asserted id order, which
+// was the Lab 1 contract. The Lab 2 contract in docs/lab-02/api-spec.md §2 —
+// written and merged before this implementation — specifies that all three
+// reference endpoints return active rows ordered by name, so that the selector
+// and Create Ticket dropdowns read alphabetically. The endpoint follows the
+// newer contract and this test follows the endpoint.
+//
+// The change is recorded rather than quiet: only the ordering assertions moved.
+// The response shape { id, name } and the four seeded categories are unchanged,
+// and active-only filtering is covered by tests/lab-02/reference.api.test.ts.
+const SEEDED_NAMES_IN_NAME_ORDER = ["Account and Access", "Hardware", "Network", "Software"];
 
 describe("GET /api/categories", () => {
-  it("returns the four seeded categories in id order", async () => {
+  it("returns the four seeded categories in name order", async () => {
     const res = await request(app).get("/api/categories");
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(4);
-    expect(res.body.map((c: { name: string }) => c.name)).toEqual(SEEDED_NAMES);
+    expect(res.body.map((c: { name: string }) => c.name)).toEqual(SEEDED_NAMES_IN_NAME_ORDER);
   });
 
-  it("returns ids in ascending order and exposes only id and name", async () => {
+  it("exposes only id and name", async () => {
     const res = await request(app).get("/api/categories");
 
-    const ids = res.body.map((c: { id: number }) => c.id);
-    expect(ids).toEqual([...ids].sort((a, b) => a - b));
-    // createdAt is an internal detail — the API contract is { id, name }.
+    // createdAt and isActive are internal details — the API contract is { id, name }.
     for (const category of res.body) {
       expect(Object.keys(category).sort()).toEqual(["id", "name"]);
     }

--- a/server/tests/lab-02/reference-failure.api.test.ts
+++ b/server/tests/lab-02/reference-failure.api.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The failure half of API-01. Prisma is mocked here — and only here — because
+// the point is what the route does when the database is unreachable, which
+// cannot be arranged against a healthy one.
+//
+// The mock is per-model rather than a blanket stub, so a route querying the
+// wrong model fails instead of silently receiving someone else's answer.
+const unreachable = () => Promise.reject(new Error("connect ECONNREFUSED 127.0.0.1:5433"));
+
+vi.mock("../../src/prisma.js", () => ({
+  getPrisma: () => ({
+    category: { findMany: unreachable },
+    relatedSystem: { findMany: unreachable },
+    requester: { findMany: unreachable },
+  }),
+}));
+
+const { default: request } = await import("supertest");
+const { app } = await import("../../src/app.js");
+
+describe("reference endpoints when the database is unreachable", () => {
+  it.each([
+    ["/api/categories"],
+    ["/api/related-systems"],
+    ["/api/requesters"],
+  ])("%s returns a safe 503 in the documented envelope", async (path) => {
+    const res = await request(app).get(path);
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      error: {
+        code: "DEPENDENCY_UNAVAILABLE",
+        message: "The service is temporarily unavailable. Please try again.",
+      },
+    });
+  });
+
+  it("never leaks the underlying cause to the client", async () => {
+    const res = await request(app).get("/api/categories");
+    const body = JSON.stringify(res.body);
+
+    // BR-41: no stack trace, no SQL, no connection string.
+    expect(body).not.toMatch(/ECONNREFUSED/);
+    expect(body).not.toMatch(/5433/);
+    expect(body).not.toMatch(/at \w+ \(/);
+  });
+});

--- a/server/tests/lab-02/reference.api.test.ts
+++ b/server/tests/lab-02/reference.api.test.ts
@@ -62,6 +62,23 @@ describe("GET /api/related-systems", () => {
       expect(Object.keys(system).sort()).toEqual(["id", "name"]);
     }
   });
+
+  it("excludes a related system that has been deactivated", async () => {
+    const prisma = getPrisma();
+    const target = await prisma.relatedSystem.findUniqueOrThrow({ where: { name: "VPN" } });
+
+    try {
+      await prisma.relatedSystem.update({ where: { id: target.id }, data: { isActive: false } });
+
+      const res = await request(app).get("/api/related-systems");
+      const names = res.body.map((system: { name: string }) => system.name);
+
+      expect(names).not.toContain("VPN");
+      expect(names).toHaveLength(RELATED_SYSTEM_NAMES.length - 1);
+    } finally {
+      await prisma.relatedSystem.update({ where: { id: target.id }, data: { isActive: true } });
+    }
+  });
 });
 
 describe("GET /api/requesters", () => {

--- a/server/tests/lab-02/reference.api.test.ts
+++ b/server/tests/lab-02/reference.api.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { CATEGORY_NAMES, RELATED_SYSTEM_NAMES, REQUESTERS } from "../../src/seed-data.js";
+
+// API-01 — the three reference endpoints (specification.md AC-01).
+//
+// These run against the real migrated and seeded database, like the Lab 1
+// suite, because what is being asserted is that the *query* excludes inactive
+// rows. A mocked Prisma would only prove that the mock returned what the mock
+// was told to return.
+//
+//   npx prisma migrate dev  &&  npm run prisma:seed
+
+const activeRequesters = REQUESTERS.filter((requester) => requester.isActive);
+const inactiveRequesters = REQUESTERS.filter((requester) => !requester.isActive);
+
+function sorted(values: readonly string[]): string[] {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+describe("GET /api/categories", () => {
+  it("returns active categories ordered by name, exposing only id and name", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((category: { name: string }) => category.name)).toEqual(sorted(CATEGORY_NAMES));
+    for (const category of res.body) {
+      expect(Object.keys(category).sort()).toEqual(["id", "name"]);
+    }
+  });
+
+  it("excludes a category that has been deactivated", async () => {
+    const prisma = getPrisma();
+    const target = await prisma.category.findUniqueOrThrow({ where: { name: "Hardware" } });
+
+    try {
+      await prisma.category.update({ where: { id: target.id }, data: { isActive: false } });
+
+      const res = await request(app).get("/api/categories");
+      const names = res.body.map((category: { name: string }) => category.name);
+
+      expect(names).not.toContain("Hardware");
+      expect(names).toHaveLength(CATEGORY_NAMES.length - 1);
+    } finally {
+      // Restore, so the suite leaves the database as it found it.
+      await prisma.category.update({ where: { id: target.id }, data: { isActive: true } });
+    }
+  });
+});
+
+describe("GET /api/related-systems", () => {
+  it("returns all seeded related systems ordered by name", async () => {
+    const res = await request(app).get("/api/related-systems");
+
+    expect(res.status).toBe(200);
+    // The labsheet requires at least six.
+    expect(res.body.length).toBeGreaterThanOrEqual(6);
+    expect(res.body.map((system: { name: string }) => system.name)).toEqual(sorted(RELATED_SYSTEM_NAMES));
+    for (const system of res.body) {
+      expect(Object.keys(system).sort()).toEqual(["id", "name"]);
+    }
+  });
+});
+
+describe("GET /api/requesters", () => {
+  it("returns only active Development Requesters, ordered by name", async () => {
+    const res = await request(app).get("/api/requesters");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(activeRequesters.length);
+    expect(res.body.map((requester: { fullName: string }) => requester.fullName)).toEqual(
+      sorted(activeRequesters.map((requester) => requester.fullName)),
+    );
+  });
+
+  it("never exposes the inactive requester to the selector", async () => {
+    // BR-06. This is the rule the seeded inactive row exists to prove.
+    expect(inactiveRequesters.length).toBeGreaterThan(0);
+
+    const res = await request(app).get("/api/requesters");
+    const emails = res.body.map((requester: { email: string }) => requester.email);
+
+    for (const requester of inactiveRequesters) {
+      expect(emails).not.toContain(requester.email);
+    }
+  });
+
+  it("exposes only id, fullName and email — no timestamps or isActive", async () => {
+    const res = await request(app).get("/api/requesters");
+
+    for (const requester of res.body) {
+      expect(Object.keys(requester).sort()).toEqual(["email", "fullName", "id"]);
+    }
+  });
+});

--- a/server/tests/lab-02/seed.test.ts
+++ b/server/tests/lab-02/seed.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { getPrisma } from "../../src/prisma.js";
+import {
+  CATEGORY_NAMES,
+  RELATED_SYSTEM_NAMES,
+  REQUESTERS,
+  seedReferenceData,
+} from "../../src/seed-data.js";
+
+// The seed has to be safe to run repeatedly (specification.md §7). Checking that
+// by hand once proves it was true once; this proves it stays true.
+
+describe("reference data seed", () => {
+  it("creates no duplicates when run a second time", async () => {
+    const prisma = getPrisma();
+
+    const before = {
+      categories: await prisma.category.count(),
+      relatedSystems: await prisma.relatedSystem.count(),
+      requesters: await prisma.requester.count(),
+    };
+
+    await seedReferenceData(prisma);
+
+    expect(await prisma.category.count()).toBe(before.categories);
+    expect(await prisma.relatedSystem.count()).toBe(before.relatedSystems);
+    expect(await prisma.requester.count()).toBe(before.requesters);
+  });
+
+  it("restores a requester that was deactivated by hand", async () => {
+    const prisma = getPrisma();
+    const target = REQUESTERS.find((requester) => requester.isActive)!;
+
+    await prisma.requester.update({ where: { email: target.email }, data: { isActive: false } });
+    await seedReferenceData(prisma);
+
+    const restored = await prisma.requester.findUniqueOrThrow({ where: { email: target.email } });
+    expect(restored.isActive).toBe(true);
+  });
+
+  it("seeds the reference data the labsheet requires", async () => {
+    const prisma = getPrisma();
+
+    expect(CATEGORY_NAMES).toHaveLength(4);
+    expect(RELATED_SYSTEM_NAMES.length).toBeGreaterThanOrEqual(6);
+    expect(REQUESTERS.filter((r) => r.isActive).length).toBeGreaterThanOrEqual(4);
+    expect(REQUESTERS.filter((r) => !r.isActive).length).toBeGreaterThanOrEqual(1);
+
+    // And no tickets, so evidence screenshots can only show tickets the
+    // application actually created (decision D-11).
+    expect(await prisma.ticket.count()).toBe(0);
+  });
+});

--- a/server/tests/setup-env.ts
+++ b/server/tests/setup-env.ts
@@ -1,0 +1,6 @@
+import { testDatabaseUrl } from "./test-database.js";
+
+// Runs in every worker before the test file is imported, so the lazy
+// PrismaClient in src/prisma.ts is built against the isolated test schema
+// rather than the development one.
+process.env.DATABASE_URL = testDatabaseUrl();

--- a/server/tests/test-database.ts
+++ b/server/tests/test-database.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Tests never run against the development database.
+//
+// Two of the Lab 2 suites deactivate a row to prove that active-only filtering
+// works. Doing that in the shared development schema means a suite that fails
+// before its cleanup leaves real data wrong, and — because Vitest runs test
+// files in parallel by default — a concurrent file can observe the temporary
+// state and fail for reasons that have nothing to do with it.
+//
+// So the whole suite runs against its own PostgreSQL schema, created, migrated
+// and seeded by tests/global-setup.ts. See also `fileParallelism: false` in
+// vitest.config.ts: an isolated schema stops tests corrupting development data,
+// but only serial execution stops them corrupting each other.
+export const TEST_SCHEMA = "lab2_test";
+
+/**
+ * Prisma Client loads server/.env itself rather than relying on process.env, so
+ * DATABASE_URL is not set in the Vitest process. Read the file directly instead
+ * of adding a dotenv dependency for one variable.
+ */
+function readDatabaseUrlFromEnvFile(): string | undefined {
+  try {
+    const contents = readFileSync(resolve(process.cwd(), ".env"), "utf8");
+    for (const line of contents.split(/\r?\n/)) {
+      const match = /^\s*DATABASE_URL\s*=\s*(.*)\s*$/.exec(line);
+      if (match) return match[1].trim().replace(/^["']|["']$/g, "");
+    }
+  } catch {
+    // No .env — fall through to the environment.
+  }
+  return undefined;
+}
+
+export function baseDatabaseUrl(): string {
+  const url = process.env.DATABASE_URL ?? readDatabaseUrlFromEnvFile();
+  if (!url) {
+    throw new Error(
+      "DATABASE_URL is not set and server/.env could not be read. " +
+        "Copy .env.example to .env before running the tests.",
+    );
+  }
+  return url;
+}
+
+/** The same database, a different schema. */
+export function testDatabaseUrl(): string {
+  const url = new URL(baseDatabaseUrl());
+  url.searchParams.set("schema", TEST_SCHEMA);
+  return url.toString();
+}

--- a/server/tests/test-database.ts
+++ b/server/tests/test-database.ts
@@ -13,7 +13,10 @@ import { resolve } from "node:path";
 // and seeded by tests/global-setup.ts. See also `fileParallelism: false` in
 // vitest.config.ts: an isolated schema stops tests corrupting development data,
 // but only serial execution stops them corrupting each other.
-export const TEST_SCHEMA = "lab2_test";
+// Typed as `string` rather than the literal, so the safety check in
+// global-setup.ts — which refuses to drop "public" — stays meaningful code
+// instead of a comparison TypeScript can prove is always false.
+export const TEST_SCHEMA: string = "lab2_test";
 
 /**
  * Prisma Client loads server/.env itself rather than relying on process.env, so

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,21 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+
+    // Create, migrate and seed an isolated PostgreSQL schema once per run, so
+    // the suite never touches the development database.
+    globalSetup: ["tests/global-setup.ts"],
+
+    // Point each worker's PrismaClient at that schema before any test imports it.
+    setupFiles: ["tests/setup-env.ts"],
+
+    // Two suites deactivate a row to prove active-only filtering. Vitest runs
+    // test files in parallel by default, so a concurrent file could observe that
+    // temporary state — categories.test.ts asserting four active categories
+    // while another file has one of them switched off. The suite is small and
+    // runs in seconds, so serial execution is cheap insurance.
+    // An isolated schema stops tests corrupting development data; this stops
+    // them corrupting each other.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary

Implements the whole Lab 2 data design in a single migration, so the issues that follow add
routes rather than tables.

- **Schema** — `Requester`, `RelatedSystem`, `Ticket` and `Attachment`, plus `isActive` on
  the existing `Category`. `RequestedPriority` is a native Postgres enum declared
  `LOW, MEDIUM, HIGH, URGENT`.
- **Seed** — the four required categories, seven related systems, four active Development
  Requesters and one inactive. No tickets, deliberately.
- **Reference APIs** — `GET /api/categories`, `/api/related-systems` and `/api/requesters`,
  active rows only, ordered by name, with the documented error envelope.

## Decisions worth a reviewer's attention

- **Soft removal is nullable columns on `Attachment`, not a boolean.** A boolean records
  *that* a file was removed but not *when*, *by whom* or *why*, which BR-37 requires.
  `removedAt IS NULL` then becomes a single indexable definition of "active", used
  identically by the list query, the download guard and the five-attachment count.
- **Priority is an enum in severity order** (D-08), so ascending sort runs
  `LOW → MEDIUM → HIGH → URGENT`. A string column would sort `HIGH, LOW, MEDIUM, URGENT`.
  The generated SQL shows `CREATE TYPE "RequestedPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT')`.
- **`idempotencyKey` is nullable and unique.** Postgres permits many NULLs under a unique
  index, so a ticket created by any path without a key is unaffected.
- **Indexes are justified against a query, not added by reflex** — `(requesterId, createdAt DESC)`
  is the My Tickets query, `(ticketId, removedAt)` is the active-attachment count.
- **The seed logic moved to `src/seed-data.ts`** so a test can execute it. A seed whose
  idempotency is only ever confirmed by a human running it twice stops being idempotent the
  moment someone edits it. `tests/lab-02/seed.test.ts` runs it a second time and asserts the
  counts are unchanged.

## One contract change, flagged rather than quiet

`GET /api/categories` previously returned rows in **id** order — the Lab 1 contract.
`api-spec.md` §2, written and merged in Issue #17 *before* this implementation, specifies
that all three reference endpoints order by **name**, so the Create Ticket and selector
dropdowns read alphabetically.

The endpoint follows the newer contract and `tests/lab-01/categories.test.ts` was updated to
match, with the reason recorded in the test file itself. **Only the ordering assertions
changed** — the `{ id, name }` response shape is untouched, and active-only filtering is now
covered by the Lab 2 suite. I am flagging it because "the test was changed to match the
code" is exactly the pattern worth challenging in review; here the spec predates both, but
you should judge that rather than take my word for it.

## Validation

- `npx prisma migrate dev --name lab2_data_model` — the migration was **generated and
  applied by Prisma against the real database**, not hand-written. Both
  `migration_lock.toml` and the migration are committed.
- `npm run prisma:seed`, run **twice** — 4 categories, 7 related systems, 5 requesters
  (4 active, 1 inactive), 0 tickets. Row counts read straight out of PostgreSQL after the
  second run were identical.
- `cd server && npm test` — 5 files, **16 tests passed**.
- `cd server && npm run build` — passed.
- The suite restores anything it mutates: after the run the database still holds 4 active
  categories, 4 active requesters and 0 tickets.

## Review focus

1. Is the soft-removal shape right, given #25 has to enforce "at most five **active**
   attachments" and still show removed ones as metadata?
2. `GET /api/requesters` returns `{ id, fullName, email }`. Is exposing the address in an
   unauthenticated endpoint acceptable for a Lab 2 testing selector, or would you rather it
   were dropped now than after #20 depends on it?
3. Does the ordering change above look justified to you, or over-reaching?

Relates to #19
