### PR TITLE
Issue 21: Create Ticket API with per-year numbering and idempotency

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -57,7 +57,8 @@ E2E rows below are not claimed runnable until it merges.
 | API-02 | API | AC-04 | A valid create returns `201` with a `TKT-` number, `NEW`, a server `ticketDate`, and the `requesterId` taken from `X-Dev-Requester-Id` rather than the body. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-03 | API | AC-05 | Each broken field rule returns `400 VALIDATION_FAILED` with that field named in `fieldErrors`, and no ticket is persisted. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-04 | API | AC-06 | Replaying an `Idempotency-Key` with an identical payload returns `200` and the original ticket with no duplicate row; replaying it with a changed payload returns `409 IDEMPOTENCY_KEY_CONFLICT` and creates nothing. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-05 | API | AC-12 | A missing, malformed, or inactive `X-Dev-Requester-Id` returns `401 REQUESTER_CONTEXT_REQUIRED` on every requester-scoped route. | `server/tests/lab-02/requester-context.api.test.ts` | Planned |
+| API-05 | API | AC-12 | A missing, malformed, or inactive `X-Dev-Requester-Id` returns `401 REQUESTER_CONTEXT_REQUIRED`, and the three causes are indistinguishable to the caller. | `server/tests/lab-02/requester-context.api.test.ts` | Planned |
+| API-16 | API | AC-06 | Two simultaneous creates sharing one `Idempotency-Key` produce exactly one Ticket: one `201`, one `200`, and the same id from both. | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-06 | API | AC-08 | The list is scoped to the header's requester: A's tickets are returned for A and are absent for B, with no query parameter involved. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-07 | API | AC-09 | Search, each filter, sorting and paging return the correct subset with correct `page`, `pageSize`, `totalItems` and `totalPages`; a page past the end returns an empty array with `200`. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-08 | API | AC-10 | Sorting by `requestedPriority` ascending returns `LOW`, `MEDIUM`, `HIGH`, `URGENT` in severity order, not alphabetical order. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
@@ -98,7 +99,7 @@ Every acceptance criterion in `specification.md` §9 maps to at least one planne
 | AC-03 Create Ticket loads reference data | UI-03 |
 | AC-04 Valid create saves one ticket with an official number | UNIT-01, API-02, UI-05, E2E-01 |
 | AC-05 Invalid create shows field errors and saves nothing | UNIT-02, API-03, UI-04 |
-| AC-06 Idempotent retry creates no duplicate | API-04 |
+| AC-06 Idempotent retry creates no duplicate | API-04, API-16 |
 | AC-07 Backend failure is safe and preserves input | UI-06, UI-12 |
 | AC-08 Tickets are scoped to the selected requester | API-06, UI-07, E2E-01, E2E-02 |
 | AC-09 Search, filter, sort, page and metadata are correct | UNIT-06, API-07, API-09, UI-08 |
@@ -157,6 +158,30 @@ npx playwright test e2e/lab-02
 unit, API and UI suites captured from `main` after the release merge, together with the
 Playwright run and the responsive screenshots. Test counts and file paths will be filled in
 from that run, not from a feature branch and not from memory.
+
+### Issue #21 feature-branch verification
+
+Run on `feature/21-create-ticket-api` on 2026-08-29, before peer review:
+
+- `npx prisma migrate dev --name lab2_ticket_number_sequence` — generated and applied by
+  Prisma against the real database.
+- `cd server && npm test` — 9 files, **55 tests passed** (was 5 files / 17).
+- `cd server && npm run build` — passed. It caught a type error the test run did not:
+  Vitest does not type-check, so `npm test` alone is not evidence that the code compiles.
+- Numbering verified in PostgreSQL rather than inferred: the suite produced
+  `TKT-2026-00001` … `TKT-2026-00008` with `TicketNumberSequence` at `year=2026,
+  lastValue=8`, and `public."Ticket"` remained empty throughout.
+
+**A note on why the create tests use the real database.** Creation is the one place a mocked
+Prisma proves least: the unique index on `idempotencyKey` and the per-year counter are
+database behaviour, and a mock returns only what it was told. API-16 in particular — two
+simultaneous requests sharing a key — cannot be written against a mock at all, because what
+is under test is which of two transactions the index rejects.
+
+**`seed.test.ts` was made order-independent.** It previously asserted an absolute zero
+Tickets. Now that this issue creates real ones in the same schema, that assertion would have
+depended on which file ran first. It now captures the count, re-seeds, and asserts the count
+is unchanged — which is the claim actually being made: *seeding* creates no tickets.
 
 ### Issue #19 feature-branch verification
 

--- a/server/prisma/migrations/20260829152516_lab2_ticket_number_sequence/migration.sql
+++ b/server/prisma/migrations/20260829152516_lab2_ticket_number_sequence/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "TicketNumberSequence" (
+    "year" INTEGER NOT NULL,
+    "lastValue" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "TicketNumberSequence_pkey" PRIMARY KEY ("year")
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -120,3 +120,15 @@ model Attachment {
   // The five-active-attachment count (BR-33) is the hottest attachment query.
   @@index([ticketId, removedAt])
 }
+
+// One row per calendar year, holding the last Ticket Number issued in it.
+//
+// BR-02 specifies a per-year sequence — TKT-2026-00001 starts again at 00001 in
+// 2027 — so the number cannot be derived from the Ticket's own autoincrement id,
+// which is global and would only ever look per-year. The counter is incremented
+// inside the same transaction as the insert, with `ON CONFLICT DO UPDATE` taking
+// a row lock, so two concurrent creates cannot be issued the same number.
+model TicketNumberSequence {
+  year      Int @id
+  lastValue Int @default(0)
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import { getPrisma } from "./prisma.js";
 import { CLIENT_ORIGIN, SERVICE_NAME } from "./config.js";
 import { sendDependencyUnavailable } from "./errors.js";
+import { createTicket } from "./tickets-route.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -72,5 +73,13 @@ app.get("/api/requesters", async (_req: Request, res: Response) => {
     sendDependencyUnavailable(res, "GET /api/requesters", err);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Issue 21 — Create Ticket (api-spec.md §3)
+//
+// Requester-scoped: identity arrives in the X-Dev-Requester-Id header, never in
+// the body, so this route describes a Ticket and nothing else (decision D-01).
+// ---------------------------------------------------------------------------
+app.post("/api/tickets", createTicket);
 
 export default app;

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -6,6 +6,8 @@ import type { Response } from "express";
 export type ErrorCode =
   | "VALIDATION_FAILED"
   | "REQUESTER_CONTEXT_REQUIRED"
+  | "IDEMPOTENCY_KEY_REQUIRED"
+  | "IDEMPOTENCY_KEY_CONFLICT"
   | "TICKET_NOT_FOUND"
   | "REFERENCE_NOT_FOUND"
   | "INTERNAL_ERROR"

--- a/server/src/requester-context.ts
+++ b/server/src/requester-context.ts
@@ -1,0 +1,46 @@
+import type { Request } from "express";
+import { getPrisma } from "./prisma.js";
+
+// The Development Requester travels in a header, not in the body or the query
+// string (decision D-01). That keeps identity out of the resource payload, gives
+// ownership checks one place to live, and makes Lab 3 a substitution at this
+// single seam rather than a change to every route signature (BR-44).
+//
+// It is emphatically not authentication: the header is trivially forgeable and
+// BR-05 says so out loud. What it buys is that every requester-scoped route
+// resolves identity the same way, so when a real identity replaces it there is
+// exactly one function to change.
+export const REQUESTER_HEADER = "x-dev-requester-id";
+
+export type RequesterContext = { id: number; fullName: string };
+
+export type RequesterContextResult =
+  | { requester: RequesterContext; failure?: never }
+  | { requester?: never; failure: "MISSING" | "MALFORMED" | "NOT_ACTIVE" };
+
+/**
+ * Resolves the header to an active Requester. A missing header, an unparseable
+ * value and an id that does not belong to an active Requester are deliberately
+ * reported the same way to the client — the distinction is useful in a log, not
+ * to a caller.
+ */
+export async function resolveRequester(req: Request): Promise<RequesterContextResult> {
+  const raw = req.header(REQUESTER_HEADER);
+  if (raw === undefined || raw.trim() === "") return { failure: "MISSING" };
+
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return { failure: "MALFORMED" };
+
+  const id = Number(trimmed);
+  if (!Number.isSafeInteger(id) || id < 1) return { failure: "MALFORMED" };
+
+  const requester = await getPrisma().requester.findFirst({
+    where: { id, isActive: true },
+    select: { id: true, fullName: true },
+  });
+
+  // An inactive Requester cannot become the active context (BR-06).
+  if (!requester) return { failure: "NOT_ACTIVE" };
+
+  return { requester };
+}

--- a/server/src/ticket-create.ts
+++ b/server/src/ticket-create.ts
@@ -1,0 +1,119 @@
+// Validation and numbering for POST /api/tickets. Kept out of app.ts so the
+// rules can be unit-tested without a database or an HTTP server — the bounds in
+// BR-12 and BR-13 are exactly the sort of thing that deserves cheap, fast tests
+// at the boundaries rather than a round trip each.
+
+export const REQUESTED_PRIORITIES = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+export type RequestedPriorityValue = (typeof REQUESTED_PRIORITIES)[number];
+
+// BR-12 and BR-13. Enforced after trimming, so whitespace cannot satisfy them.
+export const SUMMARY_MIN = 5;
+export const SUMMARY_MAX = 120;
+export const DESCRIPTION_MIN = 20;
+export const DESCRIPTION_MAX = 4000;
+
+export type NormalizedTicket = {
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  description: string;
+  requestedPriority: RequestedPriorityValue;
+};
+
+export type TicketValidation =
+  | { value: NormalizedTicket; fieldErrors?: never }
+  | { value?: never; fieldErrors: Record<string, string> };
+
+export function validateTicketCreate(body: unknown): TicketValidation {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { fieldErrors: { body: "A JSON object is required." } };
+  }
+
+  const input = body as Record<string, unknown>;
+  const fieldErrors: Record<string, string> = {};
+
+  const categoryId = reference(input.categoryId, "categoryId", "Category", fieldErrors);
+  const relatedSystemId = reference(input.relatedSystemId, "relatedSystemId", "Related System", fieldErrors);
+  const summary = bounded(input.summary, "summary", "Summary", SUMMARY_MIN, SUMMARY_MAX, fieldErrors);
+  const description = bounded(input.description, "description", "Description", DESCRIPTION_MIN, DESCRIPTION_MAX, fieldErrors);
+  const requestedPriority = priority(input.requestedPriority, fieldErrors);
+
+  if (Object.keys(fieldErrors).length > 0) return { fieldErrors };
+
+  return {
+    value: {
+      categoryId: categoryId!,
+      relatedSystemId: relatedSystemId!,
+      summary: summary!,
+      description: description!,
+      requestedPriority: requestedPriority!,
+    },
+  };
+}
+
+/**
+ * BR-02: `TKT-<YYYY>-<NNNNN>`, where the sequence restarts each calendar year.
+ * The caller supplies the value taken from the per-year counter.
+ */
+export function formatTicketNumber(year: number, sequence: number): string {
+  return `TKT-${year}-${String(sequence).padStart(5, "0")}`;
+}
+
+/**
+ * Two create requests are "the same" when the five body fields match after the
+ * same trimming validation applies (BR-19). The Requester is not compared here
+ * because it comes from the header and is checked separately — a key reused by
+ * a different Requester is still a conflict.
+ */
+export function isSameTicket(a: NormalizedTicket, b: NormalizedTicket): boolean {
+  return (
+    a.categoryId === b.categoryId &&
+    a.relatedSystemId === b.relatedSystemId &&
+    a.summary === b.summary &&
+    a.description === b.description &&
+    a.requestedPriority === b.requestedPriority
+  );
+}
+
+function reference(
+  value: unknown,
+  field: string,
+  label: string,
+  fieldErrors: Record<string, string>,
+): number | undefined {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
+    fieldErrors[field] = `Select a ${label}.`;
+    return undefined;
+  }
+  return value;
+}
+
+function bounded(
+  value: unknown,
+  field: string,
+  label: string,
+  min: number,
+  max: number,
+  fieldErrors: Record<string, string>,
+): string | undefined {
+  if (typeof value !== "string") {
+    fieldErrors[field] = `${label} is required.`;
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length < min || trimmed.length > max) {
+    fieldErrors[field] = `${label} must be ${min}-${max} characters.`;
+    return undefined;
+  }
+
+  return trimmed;
+}
+
+function priority(value: unknown, fieldErrors: Record<string, string>): RequestedPriorityValue | undefined {
+  if (typeof value !== "string" || !REQUESTED_PRIORITIES.includes(value as RequestedPriorityValue)) {
+    fieldErrors.requestedPriority = `Requested Priority must be one of ${REQUESTED_PRIORITIES.join(", ")}.`;
+    return undefined;
+  }
+  return value as RequestedPriorityValue;
+}

--- a/server/src/tickets-route.ts
+++ b/server/src/tickets-route.ts
@@ -1,0 +1,205 @@
+import type { Request, Response } from "express";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { getPrisma } from "./prisma.js";
+import { sendDependencyUnavailable, sendError } from "./errors.js";
+import { resolveRequester } from "./requester-context.js";
+import {
+  formatTicketNumber,
+  isSameTicket,
+  validateTicketCreate,
+  type NormalizedTicket,
+} from "./ticket-create.js";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// The fields every Ticket response carries (api-spec.md §3).
+const ticketSelect = {
+  id: true,
+  ticketNumber: true,
+  summary: true,
+  description: true,
+  requestedPriority: true,
+  currentStatus: true,
+  createdAt: true,
+  updatedAt: true,
+  categoryId: true,
+  relatedSystemId: true,
+  requester: { select: { id: true, fullName: true } },
+  category: { select: { id: true, name: true } },
+  relatedSystem: { select: { id: true, name: true } },
+} satisfies Prisma.TicketSelect;
+
+type TicketRow = Prisma.TicketGetPayload<{ select: typeof ticketSelect }>;
+
+function serialize(ticket: TicketRow) {
+  return {
+    id: ticket.id,
+    ticketNumber: ticket.ticketNumber,
+    // Ticket Date is the server-assigned creation timestamp (BR-04). It is named
+    // separately from createdAt because it is a field the Requester sees, not an
+    // audit column that happens to be visible.
+    ticketDate: ticket.createdAt,
+    requester: ticket.requester,
+    category: ticket.category,
+    relatedSystem: ticket.relatedSystem,
+    summary: ticket.summary,
+    description: ticket.description,
+    requestedPriority: ticket.requestedPriority,
+    currentStatus: ticket.currentStatus,
+    attachments: [] as unknown[],
+    createdAt: ticket.createdAt,
+    updatedAt: ticket.updatedAt,
+  };
+}
+
+/** Prisma's unique-constraint violation. */
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code: unknown }).code === "P2002";
+}
+
+export async function createTicket(req: Request, res: Response): Promise<void> {
+  const context = await resolveRequester(req).catch(() => null);
+  if (context === null) {
+    sendDependencyUnavailable(res, "POST /api/tickets (requester lookup)", new Error("requester lookup failed"));
+    return;
+  }
+  if (!context.requester) {
+    sendError(
+      res,
+      401,
+      "REQUESTER_CONTEXT_REQUIRED",
+      "Select a Development Requester before creating a Ticket.",
+    );
+    return;
+  }
+
+  const idempotencyKey = req.header("idempotency-key")?.trim() ?? "";
+  if (!UUID.test(idempotencyKey)) {
+    sendError(
+      res,
+      400,
+      "IDEMPOTENCY_KEY_REQUIRED",
+      "An Idempotency-Key header containing a UUID is required.",
+    );
+    return;
+  }
+
+  const validation = validateTicketCreate(req.body);
+  if (!validation.value) {
+    sendError(res, 400, "VALIDATION_FAILED", "The Ticket could not be created.", validation.fieldErrors);
+    return;
+  }
+
+  const input = validation.value;
+  const requesterId = context.requester.id;
+  const prisma = getPrisma();
+
+  try {
+    // A replay of the same key is answered before anything is created.
+    const existing = await prisma.ticket.findUnique({ where: { idempotencyKey }, select: ticketSelect });
+    if (existing) {
+      respondToReplay(res, existing, input, requesterId);
+      return;
+    }
+
+    const [category, relatedSystem] = await Promise.all([
+      prisma.category.findFirst({ where: { id: input.categoryId, isActive: true }, select: { id: true } }),
+      prisma.relatedSystem.findFirst({ where: { id: input.relatedSystemId, isActive: true }, select: { id: true } }),
+    ]);
+
+    // BR-15: both must exist and be active at the moment of creation.
+    if (!category || !relatedSystem) {
+      sendError(res, 404, "REFERENCE_NOT_FOUND", "The selected Category or Related System is unavailable.");
+      return;
+    }
+
+    const created = await createWithNumber(prisma, requesterId, input, idempotencyKey);
+    res.status(201).json(serialize(created));
+  } catch (error) {
+    // Two requests can pass the replay check at the same moment; the unique
+    // index on idempotencyKey is what actually decides. The loser re-reads and
+    // returns the winner's Ticket rather than failing (BR-19).
+    if (isUniqueViolation(error)) {
+      try {
+        const winner = await prisma.ticket.findUnique({ where: { idempotencyKey }, select: ticketSelect });
+        if (winner) {
+          respondToReplay(res, winner, input, requesterId);
+          return;
+        }
+      } catch {
+        // Fall through to the generic failure below.
+      }
+    }
+
+    sendDependencyUnavailable(res, "POST /api/tickets", error);
+  }
+}
+
+function respondToReplay(res: Response, existing: TicketRow, input: NormalizedTicket, requesterId: number): void {
+  const sameTicket = isSameTicket(
+    {
+      categoryId: existing.categoryId,
+      relatedSystemId: existing.relatedSystemId,
+      summary: existing.summary,
+      description: existing.description,
+      requestedPriority: existing.requestedPriority,
+    },
+    input,
+  );
+
+  // A key reused by a different Requester is a conflict even if the body matches.
+  if (!sameTicket || existing.requester.id !== requesterId) {
+    sendError(
+      res,
+      409,
+      "IDEMPOTENCY_KEY_CONFLICT",
+      "That Idempotency-Key has already been used for a different Ticket.",
+    );
+    return;
+  }
+
+  res.status(200).json(serialize(existing));
+}
+
+/**
+ * BR-20: the Ticket and its official number are written in one transaction, so a
+ * failure rolls back both and no number is consumed by a Ticket that does not
+ * exist.
+ *
+ * The number is taken from a per-year counter *before* the insert, so the row is
+ * never written with a placeholder number that would have to be corrected by a
+ * second statement.
+ */
+async function createWithNumber(
+  prisma: PrismaClient,
+  requesterId: number,
+  input: NormalizedTicket,
+  idempotencyKey: string,
+): Promise<TicketRow> {
+  return prisma.$transaction(async (tx) => {
+    const year = new Date().getUTCFullYear();
+
+    // ON CONFLICT DO UPDATE takes a row lock, so concurrent creates in the same
+    // year are serialised and cannot be issued the same sequence value.
+    const rows = await tx.$queryRaw<{ lastValue: number }[]>`
+      INSERT INTO "TicketNumberSequence" ("year", "lastValue")
+      VALUES (${year}, 1)
+      ON CONFLICT ("year") DO UPDATE SET "lastValue" = "TicketNumberSequence"."lastValue" + 1
+      RETURNING "lastValue"
+    `;
+
+    return tx.ticket.create({
+      data: {
+        ticketNumber: formatTicketNumber(year, rows[0].lastValue),
+        requesterId,
+        categoryId: input.categoryId,
+        relatedSystemId: input.relatedSystemId,
+        summary: input.summary,
+        description: input.description,
+        requestedPriority: input.requestedPriority,
+        idempotencyKey,
+      },
+      select: ticketSelect,
+    });
+  });
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { REQUESTER_HEADER } from "../../src/requester-context.js";
+
+// API-02, API-03, API-04 — AC-04, AC-05, AC-06.
+//
+// These run against the real migrated database in the isolated lab2_test schema.
+// Creation is where a mocked Prisma would be least convincing: the unique index
+// on idempotencyKey and the per-year counter are database behaviour, and a mock
+// can only return what it was told.
+
+const prisma = getPrisma();
+
+let requesterId = 0;
+let otherRequesterId = 0;
+let categoryId = 0;
+let relatedSystemId = 0;
+
+function body(overrides: Record<string, unknown> = {}) {
+  return {
+    categoryId,
+    relatedSystemId,
+    summary: "Cannot connect to Campus Wi-Fi in Building 4",
+    description: "The laptop reports an authentication failure on the campus network every morning.",
+    requestedPriority: "HIGH",
+    ...overrides,
+  };
+}
+
+// `key` is typed as plain string rather than inferred from randomUUID(), whose
+// template-literal type would reject the deliberately malformed key below.
+function post(overrides: Record<string, unknown> = {}, key: string = randomUUID(), asRequester?: number) {
+  return request(app)
+    .post("/api/tickets")
+    .set(REQUESTER_HEADER, String(asRequester ?? requesterId))
+    .set("Idempotency-Key", key)
+    .send(body(overrides));
+}
+
+beforeAll(async () => {
+  const [active, category, relatedSystem] = await Promise.all([
+    prisma.requester.findMany({ where: { isActive: true }, orderBy: { id: "asc" }, take: 2 }),
+    prisma.category.findFirstOrThrow({ where: { isActive: true } }),
+    prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true } }),
+  ]);
+  requesterId = active[0].id;
+  otherRequesterId = active[1].id;
+  categoryId = category.id;
+  relatedSystemId = relatedSystem.id;
+});
+
+describe("POST /api/tickets — success", () => {
+  it("saves one ticket owned by the header's requester, with a server-assigned number", async () => {
+    const before = await prisma.ticket.count();
+    const res = await post();
+
+    expect(res.status).toBe(201);
+    expect(res.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{5,}$/);
+    expect(res.body.currentStatus).toBe("NEW");
+    expect(res.body.requester.id).toBe(requesterId);
+    expect(res.body.ticketDate).toBeTruthy();
+    expect(res.body.attachments).toEqual([]);
+
+    // AC-04 asks that the ticket is *saved*, so check the row, not the response.
+    const saved = await prisma.ticket.findUniqueOrThrow({ where: { id: res.body.id } });
+    expect(saved.requesterId).toBe(requesterId);
+    expect(saved.currentStatus).toBe("NEW");
+    expect(await prisma.ticket.count()).toBe(before + 1);
+  });
+
+  it("never returns a placeholder number — the number is issued before the insert", async () => {
+    const res = await post();
+    expect(res.body.ticketNumber).not.toMatch(/PENDING|TEMP|null|undefined/i);
+  });
+
+  it("issues increasing numbers within the same year", async () => {
+    const first = await post();
+    const second = await post();
+
+    const sequence = (n: string) => Number(n.split("-")[2]);
+    expect(sequence(second.body.ticketNumber)).toBe(sequence(first.body.ticketNumber) + 1);
+    expect(first.body.ticketNumber.slice(0, 8)).toBe(second.body.ticketNumber.slice(0, 8));
+  });
+});
+
+describe("POST /api/tickets — validation", () => {
+  it("returns field errors and saves nothing", async () => {
+    const before = await prisma.ticket.count();
+    const res = await post({ summary: "no", description: "too short", requestedPriority: "SOMEDAY" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(Object.keys(res.body.error.fieldErrors).sort()).toEqual([
+      "description",
+      "requestedPriority",
+      "summary",
+    ]);
+    expect(await prisma.ticket.count()).toBe(before);
+  });
+
+  it("rejects an inactive or unknown Category as not found", async () => {
+    const inactive = await prisma.category.create({
+      data: { name: `Retired category ${randomUUID()}`, isActive: false },
+    });
+
+    try {
+      const res = await post({ categoryId: inactive.id });
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe("REFERENCE_NOT_FOUND");
+    } finally {
+      await prisma.category.delete({ where: { id: inactive.id } });
+    }
+  });
+
+  it("requires an Idempotency-Key header containing a UUID", async () => {
+    const missing = await request(app)
+      .post("/api/tickets")
+      .set(REQUESTER_HEADER, String(requesterId))
+      .send(body());
+    expect(missing.status).toBe(400);
+    expect(missing.body.error.code).toBe("IDEMPOTENCY_KEY_REQUIRED");
+
+    const malformed = await post({}, "not-a-uuid");
+    expect(malformed.body.error.code).toBe("IDEMPOTENCY_KEY_REQUIRED");
+  });
+});
+
+describe("POST /api/tickets — idempotency", () => {
+  it("replaying the same key and payload returns the original and creates nothing", async () => {
+    const key = randomUUID();
+    const first = await post({}, key);
+    const before = await prisma.ticket.count();
+
+    const replay = await post({}, key);
+
+    expect(replay.status).toBe(200);
+    expect(replay.body.id).toBe(first.body.id);
+    expect(replay.body.ticketNumber).toBe(first.body.ticketNumber);
+    expect(await prisma.ticket.count()).toBe(before);
+  });
+
+  it("reusing a key with a different payload is a conflict and creates nothing", async () => {
+    const key = randomUUID();
+    await post({}, key);
+    const before = await prisma.ticket.count();
+
+    const conflict = await post({ summary: "A completely different problem entirely" }, key);
+
+    expect(conflict.status).toBe(409);
+    expect(conflict.body.error.code).toBe("IDEMPOTENCY_KEY_CONFLICT");
+    expect(await prisma.ticket.count()).toBe(before);
+  });
+
+  it("reusing a key from a different requester is a conflict even when the body matches", async () => {
+    const key = randomUUID();
+    await post({}, key);
+
+    const conflict = await post({}, key, otherRequesterId);
+
+    expect(conflict.status).toBe(409);
+    expect(conflict.body.error.code).toBe("IDEMPOTENCY_KEY_CONFLICT");
+  });
+
+  it("two simultaneous requests with one key create exactly one ticket", async () => {
+    // The replay check and the insert are not atomic together, so the unique
+    // index is what actually decides. The loser must return the winner's ticket
+    // rather than a 500.
+    const key = randomUUID();
+    const before = await prisma.ticket.count();
+
+    const [a, b] = await Promise.all([post({}, key), post({}, key)]);
+
+    expect([a.status, b.status].sort()).toEqual([200, 201]);
+    expect(a.body.id).toBe(b.body.id);
+    expect(await prisma.ticket.count()).toBe(before + 1);
+  });
+});

--- a/server/tests/lab-02/requester-context.api.test.ts
+++ b/server/tests/lab-02/requester-context.api.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { REQUESTER_HEADER } from "../../src/requester-context.js";
+
+// API-05 — AC-12. The identity seam is the one place Lab 3 will replace, so the
+// rules it enforces are worth testing directly rather than only through the
+// routes that depend on it.
+
+const prisma = getPrisma();
+let categoryId = 0;
+let relatedSystemId = 0;
+let inactiveRequesterId = 0;
+
+const validBody = () => ({
+  categoryId,
+  relatedSystemId,
+  summary: "Cannot connect to Campus Wi-Fi in Building 4",
+  description: "The laptop reports an authentication failure on the campus network every morning.",
+  requestedPriority: "HIGH",
+});
+
+beforeAll(async () => {
+  const [category, relatedSystem, inactive] = await Promise.all([
+    prisma.category.findFirstOrThrow({ where: { isActive: true } }),
+    prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true } }),
+    prisma.requester.findFirstOrThrow({ where: { isActive: false } }),
+  ]);
+  categoryId = category.id;
+  relatedSystemId = relatedSystem.id;
+  inactiveRequesterId = inactive.id;
+});
+
+function post(header?: string) {
+  const req = request(app).post("/api/tickets").set("Idempotency-Key", randomUUID());
+  if (header !== undefined) req.set(REQUESTER_HEADER, header);
+  return req.send(validBody());
+}
+
+describe("Development Requester context", () => {
+  it.each([
+    ["missing", undefined],
+    ["empty", "   "],
+    ["not a number", "abc"],
+    ["negative", "-1"],
+    ["zero", "0"],
+    ["unknown id", "999999"],
+  ])("rejects a %s requester header with 401", async (_label, header) => {
+    const res = await post(header as string | undefined);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("REQUESTER_CONTEXT_REQUIRED");
+  });
+
+  it("rejects an inactive Requester — BR-06, they cannot become the active context", async () => {
+    const before = await prisma.ticket.count();
+    const res = await post(String(inactiveRequesterId));
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("REQUESTER_CONTEXT_REQUIRED");
+    expect(await prisma.ticket.count()).toBe(before);
+  });
+
+  it("never reveals whether the id was unknown, inactive, or malformed", async () => {
+    // Three different internal causes, one external answer.
+    const responses = await Promise.all([post("abc"), post("999999"), post(String(inactiveRequesterId))]);
+    const bodies = responses.map((res) => JSON.stringify(res.body));
+
+    expect(new Set(bodies).size).toBe(1);
+  });
+});

--- a/server/tests/lab-02/seed.test.ts
+++ b/server/tests/lab-02/seed.test.ts
@@ -46,8 +46,15 @@ describe("reference data seed", () => {
     expect(REQUESTERS.filter((r) => r.isActive).length).toBeGreaterThanOrEqual(4);
     expect(REQUESTERS.filter((r) => !r.isActive).length).toBeGreaterThanOrEqual(1);
 
-    // And no tickets, so evidence screenshots can only show tickets the
-    // application actually created (decision D-11).
-    expect(await prisma.ticket.count()).toBe(0);
+    // And the seed creates no tickets, so evidence screenshots can only show
+    // tickets the application actually created (decision D-11).
+    //
+    // Asserted as a delta rather than an absolute zero: the create-ticket suite
+    // now makes real tickets in this schema, and an absolute count would make
+    // this test depend on which file ran first. What is actually being claimed
+    // is that *seeding* adds none.
+    const ticketsBefore = await prisma.ticket.count();
+    await seedReferenceData(prisma);
+    expect(await prisma.ticket.count()).toBe(ticketsBefore);
   });
 });

--- a/server/tests/lab-02/ticket-number.test.ts
+++ b/server/tests/lab-02/ticket-number.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { formatTicketNumber } from "../../src/ticket-create.js";
+
+// UNIT-01 — BR-02. The format is part of the contract: it appears on the success
+// screen, in search, and in every screenshot the report carries, so it is worth
+// pinning rather than trusting.
+
+describe("ticket number format", () => {
+  it("is TKT-<year>-<sequence> zero padded to five digits", () => {
+    expect(formatTicketNumber(2026, 1)).toBe("TKT-2026-00001");
+    expect(formatTicketNumber(2026, 42)).toBe("TKT-2026-00042");
+    expect(formatTicketNumber(2026, 99999)).toBe("TKT-2026-99999");
+  });
+
+  it("restarts the sequence in a new year rather than continuing", () => {
+    // The whole reason the number comes from a per-year counter and not from the
+    // Ticket's own autoincrement id: an id would keep climbing across the year
+    // boundary and only look per-year.
+    expect(formatTicketNumber(2026, 812)).toBe("TKT-2026-00812");
+    expect(formatTicketNumber(2027, 1)).toBe("TKT-2027-00001");
+  });
+
+  it("does not truncate a sequence that outgrows the padding", () => {
+    // Better a six-digit number than a wrong five-digit one.
+    expect(formatTicketNumber(2026, 100000)).toBe("TKT-2026-100000");
+  });
+});

--- a/server/tests/lab-02/ticket-validation.test.ts
+++ b/server/tests/lab-02/ticket-validation.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  DESCRIPTION_MAX,
+  DESCRIPTION_MIN,
+  SUMMARY_MAX,
+  SUMMARY_MIN,
+  isSameTicket,
+  validateTicketCreate,
+} from "../../src/ticket-create.js";
+
+// UNIT-02 — BR-12, BR-13, BR-14, BR-17. Boundaries belong in unit tests: they
+// are the cases most likely to be off by one and the cheapest to check here.
+
+const valid = {
+  categoryId: 1,
+  relatedSystemId: 2,
+  summary: "Cannot connect to Campus Wi-Fi",
+  description: "The laptop reports an authentication failure on the campus network every morning.",
+  requestedPriority: "HIGH",
+};
+
+describe("ticket create validation", () => {
+  it("accepts a valid ticket and returns the trimmed values", () => {
+    const result = validateTicketCreate({
+      ...valid,
+      summary: "   Cannot connect to Campus Wi-Fi   ",
+      description: `  ${valid.description}  `,
+    });
+
+    expect(result.fieldErrors).toBeUndefined();
+    expect(result.value?.summary).toBe("Cannot connect to Campus Wi-Fi");
+    expect(result.value?.description).toBe(valid.description);
+  });
+
+  it("rejects whitespace that would otherwise satisfy the minimum", () => {
+    // Trim happens before the length check, so spaces cannot pad a value into
+    // validity (BR-12).
+    const result = validateTicketCreate({ ...valid, summary: " ".repeat(50) });
+    expect(result.value).toBeUndefined();
+    expect(result.fieldErrors?.summary).toMatch(/5-120/);
+  });
+
+  it.each([
+    ["summary", SUMMARY_MIN - 1, false],
+    ["summary", SUMMARY_MIN, true],
+    ["summary", SUMMARY_MAX, true],
+    ["summary", SUMMARY_MAX + 1, false],
+    ["description", DESCRIPTION_MIN - 1, false],
+    ["description", DESCRIPTION_MIN, true],
+    ["description", DESCRIPTION_MAX, true],
+    ["description", DESCRIPTION_MAX + 1, false],
+  ])("%s of length %i is accepted=%s", (field, length, accepted) => {
+    const result = validateTicketCreate({ ...valid, [field]: "x".repeat(length) });
+    expect(result.value !== undefined).toBe(accepted);
+  });
+
+  it("rejects a priority outside the allowed set", () => {
+    const result = validateTicketCreate({ ...valid, requestedPriority: "CRITICAL" });
+    expect(result.fieldErrors?.requestedPriority).toMatch(/LOW, MEDIUM, HIGH, URGENT/);
+  });
+
+  it("reports every broken field at once rather than the first", () => {
+    // BR-17: the user should be able to fix the whole form in one pass.
+    const result = validateTicketCreate({
+      categoryId: 0,
+      relatedSystemId: "two",
+      summary: "no",
+      description: "short",
+      requestedPriority: "SOMEDAY",
+    });
+
+    expect(Object.keys(result.fieldErrors ?? {}).sort()).toEqual([
+      "categoryId",
+      "description",
+      "relatedSystemId",
+      "requestedPriority",
+      "summary",
+    ]);
+  });
+
+  it.each([null, "a string", 42, ["an", "array"]])("rejects %s as a body", (body) => {
+    expect(validateTicketCreate(body).fieldErrors).toBeDefined();
+  });
+
+  it("treats two payloads as the same only when every field matches after trimming", () => {
+    const a = validateTicketCreate(valid).value!;
+    const b = validateTicketCreate({ ...valid, summary: `  ${valid.summary}  ` }).value!;
+    const c = validateTicketCreate({ ...valid, requestedPriority: "LOW" }).value!;
+
+    expect(isSameTicket(a, b)).toBe(true);
+    expect(isSameTicket(a, c)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/tickets` — validated creation, a backend-issued Ticket Number, and idempotency.

- **`src/requester-context.ts`** — resolves `X-Dev-Requester-Id`. Identity lives in a header,
  not the body, so the route describes a Ticket and nothing else (D-01). This is the single
  seam Lab 3 replaces.
- **`src/ticket-create.ts`** — validation and number formatting, with no database in sight,
  so the BR-12/BR-13 boundaries are tested at the boundary.
- **`src/tickets-route.ts`** — creation, idempotency, safe errors.

## The ticket number needed a counter, not the row id

BR-02 specifies a **per-year** sequence — `TKT-2026-00001` starts again at `00001` in 2027.
A Ticket's own autoincrement id cannot provide that: it is global, and prefixing it with the
year only makes it *look* per-year.

So there is a `TicketNumberSequence` table, one row per year, incremented inside the same
transaction as the insert:

```sql
INSERT INTO "TicketNumberSequence" ("year", "lastValue") VALUES ($1, 1)
ON CONFLICT ("year") DO UPDATE SET "lastValue" = "TicketNumberSequence"."lastValue" + 1
RETURNING "lastValue"
```

`ON CONFLICT DO UPDATE` takes a row lock, so concurrent creates in the same year are
serialised and cannot receive the same number. Because the number is issued *before* the
insert, no row is ever written with a placeholder that a second statement has to correct.

Verified in PostgreSQL rather than inferred — the suite produced `TKT-2026-00001` through
`TKT-2026-00008` with the counter at `lastValue = 8`.

## Idempotency, and a pattern borrowed from your PR #22

Replaying a key with the same payload returns the original with `200`. Reusing it with a
different payload — or from a different Requester, even when the body matches — returns
`409`.

The pre-check and the insert are not atomic together, so the unique index is what actually
decides. The losing request catches `P2002`, re-reads, and returns the winner's Ticket
rather than failing. **That is the defensive pattern from your `POST /api/tickets`** — I
probed it during that review, could not break it, and thought it worth adopting rather than
inventing something weaker. API-16 covers it: two simultaneous requests with one key produce
one `201`, one `200`, the same id, and exactly one row.

## Validation

- `cd server && npm test` — 9 files, **55 tests passed** (up from 5 files / 17).
- `cd server && npm run build` — passed, and **it caught a type error the test run did
  not**: Vitest does not type-check, so a green `npm test` is not evidence that the code
  compiles. Worth remembering for both of us.
- The development schema stayed empty throughout; all rows went to the isolated `lab2_test`
  schema from #19.

**The create tests use the real database on purpose.** Creation is where a mocked Prisma
proves least — the unique index and the counter *are* database behaviour, and a mock returns
what it was told. API-16 could not be written against a mock at all, because what is under
test is which of two transactions the index rejects. (This is the same argument I made on
your PR #24 about owner scoping, so it seemed only fair to hold this PR to it.)

`seed.test.ts` was also made order-independent: it asserted an absolute zero Tickets, which
would now depend on which file ran first. It captures the count, re-seeds, and asserts the
count is unchanged — the claim actually being made is that *seeding* creates none.

## Review focus

1. Is the `409` on a key reused by a *different Requester* right, or should a key be scoped
   per Requester so the same UUID from two people is simply two Tickets?
2. `TicketNumberSequence` adds a second migration on top of #19's. Is a counter table the
   right call for BR-02, or would you rather relax the rule to a global sequence and drop
   the table?
3. Does anything in the error envelope drift from `api-spec.md` §3?

Relates to #21
