### PR TITLE
Issue 20: Development Requester selection, context and route guard

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -970,6 +971,15 @@
       ],
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2729,6 +2739,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/redent": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,78 +1,88 @@
-import { useState } from "react";
-import { checkSystem, Category } from "./api.js";
-import {
-  AppShell,
-  Button,
-  Card,
-  EmptyState,
-  ErrorAlert,
-  StatusMessage,
-  type NavItem,
-} from "./components/index.js";
+import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { AppShell, Card, type NavItem } from "./components/index.js";
+import SystemCheck from "./SystemCheck.js";
+import { RequesterProvider, RequesterSelector, RequireRequester, useRequester } from "./requester/index.js";
 
-// UI states you must handle for Issue 4: idle, loading, success, error.
-type UiState = "idle" | "loading" | "success" | "error";
-
-// Create Ticket and My Tickets arrive with Issues #22 and #24. They are shown
-// disabled rather than hidden so the shell is honest about what exists.
-const NAV_ITEMS: NavItem[] = [
-  { key: "system-check", label: "System Check" },
-  { key: "create-ticket", label: "Create Ticket", disabled: true },
-  { key: "my-tickets", label: "My Tickets", disabled: true },
-];
+// Routes, so that AC-02 — opening a requester-scoped route directly shows the
+// selector — is a real claim about a real URL rather than about which branch of
+// a conditional happened to render.
 
 export default function App() {
-  const [state, setState] = useState<UiState>("idle");
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [error, setError] = useState("");
+  return (
+    <RequesterProvider>
+      <Shell />
+    </RequesterProvider>
+  );
+}
 
-  async function handleCheck() {
-    setState("loading");
-    setError("");
-    try {
-      const status = await checkSystem();
-      setCategories(status.categories);
-      setState("success");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not reach the API.");
-      setState("error");
-    }
+function Shell() {
+  const { requester, clear } = useRequester();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Navigation is hidden until a Requester is chosen: on the selector screen
+  // there is nothing behind those links yet, and offering them would invite the
+  // guard to bounce the user straight back.
+  const navItems: NavItem[] = requester
+    ? [
+        { key: "/create", label: "Create Ticket", onSelect: () => navigate("/create") },
+        { key: "/tickets", label: "My Tickets", onSelect: () => navigate("/tickets") },
+      ]
+    : [];
+
+  function changeRequester() {
+    // BR-11: drop the context first, so requester-scoped screens unmount before
+    // the selector appears rather than briefly showing the old requester's data.
+    clear();
+    navigate("/select-requester", { replace: true });
   }
 
   return (
-    <AppShell navItems={NAV_ITEMS} activeKey="system-check">
-      <Card title="IT Service Desk" as="h1">
-        <Button variant="primary" onClick={handleCheck} busy={state === "loading"} busyLabel="Loading…">
-          Check System
-        </Button>
-
-        {state === "loading" && <StatusMessage>Checking the API…</StatusMessage>}
-
-        {state === "success" && (
-          <>
-            <p>
-              System Status: <span className="zen-text-success">Online</span>
-            </p>
-
-            <h2 className="zen-section-title">Supported Request Categories:</h2>
-            {categories.length === 0 ? (
-              <EmptyState title="No categories found." />
-            ) : (
-              <ul className="zen-list">
-                {categories.map((category) => (
-                  <li key={category.id}>{category.name}</li>
-                ))}
-              </ul>
-            )}
-          </>
-        )}
-
-        {state === "error" && (
-          <ErrorAlert onRetry={handleCheck}>
-            System Status: <span className="zen-text-error">Offline</span> — {error}
-          </ErrorAlert>
-        )}
-      </Card>
+    <AppShell
+      navItems={navItems}
+      activeKey={location.pathname}
+      requesterName={requester?.fullName}
+      onChangeRequester={requester ? changeRequester : undefined}
+    >
+      <Routes>
+        <Route path="/select-requester" element={<RequesterSelector />} />
+        <Route
+          path="/create"
+          element={
+            <RequireRequester>
+              <ComingSoon title="Create Ticket" issue={22} />
+            </RequireRequester>
+          }
+        />
+        <Route
+          path="/tickets"
+          element={
+            <RequireRequester>
+              <ComingSoon title="My Tickets" issue={24} />
+            </RequireRequester>
+          }
+        />
+        <Route path="/system-check" element={<SystemCheck />} />
+        <Route path="*" element={<Navigate to="/tickets" replace />} />
+      </Routes>
     </AppShell>
+  );
+}
+
+/**
+ * A screen that exists as a route but not yet as a feature. Shown rather than
+ * hidden so the shell, the navigation and the guard are all real and reviewable
+ * now, and says which issue delivers it rather than implying it is broken.
+ */
+function ComingSoon({ title, issue }: { title: string; issue: number }) {
+  const { requester } = useRequester();
+
+  return (
+    <Card title={title} as="h1">
+      <p>
+        This screen is delivered by Issue #{issue}. The Development Requester context is
+        already in place: you are working as <strong>{requester?.fullName}</strong>.
+      </p>
+    </Card>
   );
 }

--- a/client/src/SystemCheck.tsx
+++ b/client/src/SystemCheck.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { checkSystem, Category } from "./api.js";
+import { Button, Card, EmptyState, ErrorAlert, StatusMessage } from "./components/index.js";
+
+// The Lab 1 system check, moved out of App.tsx when App became the router in
+// Issue #20. The markup and behaviour are unchanged — only where it is mounted
+// moved, and tests/lab-01/App.test.tsx now renders this component directly.
+
+// UI states you must handle for Issue 4: idle, loading, success, error.
+type UiState = "idle" | "loading" | "success" | "error";
+
+export default function SystemCheck() {
+  const [state, setState] = useState<UiState>("idle");
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [error, setError] = useState("");
+
+  async function handleCheck() {
+    setState("loading");
+    setError("");
+    try {
+      const status = await checkSystem();
+      setCategories(status.categories);
+      setState("success");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not reach the API.");
+      setState("error");
+    }
+  }
+
+  return (
+      <Card title="IT Service Desk" as="h1">
+        <Button variant="primary" onClick={handleCheck} busy={state === "loading"} busyLabel="Loading…">
+          Check System
+        </Button>
+
+        {state === "loading" && <StatusMessage>Checking the API…</StatusMessage>}
+
+        {state === "success" && (
+          <>
+            <p>
+              System Status: <span className="zen-text-success">Online</span>
+            </p>
+
+            <h2 className="zen-section-title">Supported Request Categories:</h2>
+            {categories.length === 0 ? (
+              <EmptyState title="No categories found." />
+            ) : (
+              <ul className="zen-list">
+                {categories.map((category) => (
+                  <li key={category.id}>{category.name}</li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+
+        {state === "error" && (
+          <ErrorAlert onRetry={handleCheck}>
+            System Status: <span className="zen-text-error">Offline</span> — {error}
+          </ErrorAlert>
+        )}
+      </Card>
+  );
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,6 +10,14 @@ export interface SystemStatus {
   categories: Category[];
 }
 
+// A Development Requester as the selector sees one. The API deliberately
+// exposes no more than this: no isActive, no timestamps (api-spec.md §2).
+export interface Requester {
+  id: number;
+  fullName: string;
+  email: string;
+}
+
 // Shown to the user whenever the API cannot be reached at all. A rejected fetch
 // gives a raw browser error such as "TypeError: Failed to fetch", which is
 // jargon; the acceptance criterion asks for a useful message instead.
@@ -41,4 +49,15 @@ export async function checkSystem(): Promise<SystemStatus> {
 
   const categories = (await response.json()) as Category[];
   return { online: true, categories };
+}
+
+// Issue 20 — the active Development Requesters offered by the selector.
+// Inactive requesters are excluded by the API, not filtered here (BR-06): the
+// client is not the thing that decides who may be selected.
+export async function fetchRequesters(): Promise<Requester[]> {
+  const response = await request(`${API_URL}/api/requesters`);
+  if (!response.ok) {
+    throw new Error("Could not load Development Requesters.");
+  }
+  return (await response.json()) as Requester[];
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import "./styles/zen-green.css";
 import App from "./App.js";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/client/src/requester/RequesterContext.tsx
+++ b/client/src/requester/RequesterContext.tsx
@@ -1,0 +1,107 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { fetchRequesters, type Requester } from "../api.js";
+
+// Only the id is persisted (BR-07). There is no credential or token in Lab 2 to
+// persist, and storing the whole requester would let a stale name or e-mail
+// survive a change on the server.
+const STORAGE_KEY = "toktickit.lab2.requesterId";
+
+type RequesterContextValue = {
+  requester: Requester | null;
+  /** True until the stored selection has been resolved against the API. */
+  restoring: boolean;
+  select: (requester: Requester) => void;
+  clear: () => void;
+};
+
+const RequesterContext = createContext<RequesterContextValue | null>(null);
+
+function readStoredId(): number | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return null;
+    const id = Number(raw);
+    return Number.isSafeInteger(id) && id > 0 ? id : null;
+  } catch {
+    // Storage can throw in a private window. A missing selection is recoverable;
+    // an exception on mount is not.
+    return null;
+  }
+}
+
+function writeStoredId(id: number | null): void {
+  try {
+    if (id === null) window.localStorage.removeItem(STORAGE_KEY);
+    else window.localStorage.setItem(STORAGE_KEY, String(id));
+  } catch {
+    // Selection still works for this session; it just will not survive a reload.
+  }
+}
+
+export function RequesterProvider({ children }: { children: ReactNode }) {
+  const [requester, setRequester] = useState<Requester | null>(null);
+  const [restoring, setRestoring] = useState(true);
+
+  // A stored id is a claim, not a fact. It is resolved against the live list of
+  // *active* requesters, so a selection whose requester has since been
+  // deactivated is dropped rather than silently kept (BR-06).
+  useEffect(() => {
+    const storedId = readStoredId();
+    if (storedId === null) {
+      setRestoring(false);
+      return;
+    }
+
+    let cancelled = false;
+    fetchRequesters()
+      .then((requesters) => {
+        if (cancelled) return;
+        const match = requesters.find((candidate) => candidate.id === storedId) ?? null;
+        if (match === null) writeStoredId(null);
+        setRequester(match);
+      })
+      .catch(() => {
+        // The API is unreachable. Keep the stored id for a later reload rather
+        // than discarding a valid selection because the network blipped, but do
+        // not pretend a requester is selected.
+        if (!cancelled) setRequester(null);
+      })
+      .finally(() => {
+        if (!cancelled) setRestoring(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const select = useCallback((next: Requester) => {
+    writeStoredId(next.id);
+    setRequester(next);
+  }, []);
+
+  // BR-11: changing requester clears the selection so requester-scoped screens
+  // unmount and refetch under the new context rather than showing the previous
+  // requester's data while they load.
+  const clear = useCallback(() => {
+    writeStoredId(null);
+    setRequester(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({ requester, restoring, select, clear }),
+    [requester, restoring, select, clear],
+  );
+
+  return <RequesterContext.Provider value={value}>{children}</RequesterContext.Provider>;
+}
+
+export function useRequester(): RequesterContextValue {
+  const value = useContext(RequesterContext);
+  if (value === null) {
+    throw new Error("useRequester must be used inside a RequesterProvider.");
+  }
+  return value;
+}
+
+export const REQUESTER_STORAGE_KEY = STORAGE_KEY;

--- a/client/src/requester/RequesterSelector.tsx
+++ b/client/src/requester/RequesterSelector.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { fetchRequesters, type Requester } from "../api.js";
+import { Button, Card, EmptyState, ErrorAlert, Field, StatusMessage } from "../components/index.js";
+import { useRequester } from "./RequesterContext.js";
+
+type LoadState = "loading" | "ready" | "failed";
+
+/**
+ * The Development Requester selection screen (ui-spec.md §5).
+ *
+ * It says what it is out loud. Lab 2 has no authentication, and a screen that
+ * looks like a login while providing none is worse than one that admits it.
+ */
+export default function RequesterSelector() {
+  const [requesters, setRequesters] = useState<Requester[]>([]);
+  const [state, setState] = useState<LoadState>("loading");
+  const [selectedId, setSelectedId] = useState("");
+  const { select } = useRequester();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Where the visitor was trying to go before the guard sent them here.
+  const returnTo = (location.state as { from?: string } | null)?.from ?? "/tickets";
+
+  async function load() {
+    setState("loading");
+    try {
+      setRequesters(await fetchRequesters());
+      setState("ready");
+    } catch {
+      setState("failed");
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  function onContinue() {
+    const chosen = requesters.find((candidate) => String(candidate.id) === selectedId);
+    if (!chosen) return;
+    select(chosen);
+    navigate(returnTo, { replace: true });
+  }
+
+  return (
+    <Card title="Development Requester Selection" as="h1">
+      <p>
+        Select a Development Requester to test requester-specific ticket behaviour.
+        <strong> This is not a login screen and provides no security.</strong>
+      </p>
+
+      {state === "loading" && <StatusMessage>Loading Development Requesters…</StatusMessage>}
+
+      {state === "failed" && (
+        <ErrorAlert onRetry={() => void load()}>
+          Development Requesters could not be loaded. Please try again.
+        </ErrorAlert>
+      )}
+
+      {state === "ready" && requesters.length === 0 && (
+        <EmptyState
+          title="No active Development Requesters are available."
+          description="Seed the database with npm run prisma:seed, then reload this page."
+        />
+      )}
+
+      {state === "ready" && requesters.length > 0 && (
+        <>
+          <Field id="development-requester" label="Development Requester" required>
+            {(control) => (
+              <select
+                {...control}
+                value={selectedId}
+                onChange={(event) => setSelectedId(event.target.value)}
+              >
+                <option value="">Choose a Development Requester</option>
+                {requesters.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>
+                    {candidate.fullName} — {candidate.email}
+                  </option>
+                ))}
+              </select>
+            )}
+          </Field>
+
+          <Button onClick={onContinue} disabled={selectedId === ""}>
+            Continue
+          </Button>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/client/src/requester/RequireRequester.tsx
+++ b/client/src/requester/RequireRequester.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { StatusMessage } from "../components/index.js";
+import { useRequester } from "./RequesterContext.js";
+
+/**
+ * AC-02 — a requester-scoped route opened directly shows the selector rather
+ * than any ticket data.
+ *
+ * The guard is a route wrapper rather than a check inside each screen, so a
+ * screen added later cannot forget it. It is a usability guard, not a security
+ * one: the server enforces ownership on every request regardless (BR-08), and
+ * this only decides what the browser renders.
+ */
+export default function RequireRequester({ children }: { children: ReactNode }) {
+  const { requester, restoring } = useRequester();
+  const location = useLocation();
+
+  // Rendering the redirect before the stored selection has been resolved would
+  // bounce a returning user to the selector on every reload.
+  if (restoring) {
+    return <StatusMessage>Restoring your Development Requester…</StatusMessage>;
+  }
+
+  if (requester === null) {
+    return <Navigate to="/select-requester" replace state={{ from: location.pathname }} />;
+  }
+
+  return <>{children}</>;
+}

--- a/client/src/requester/index.ts
+++ b/client/src/requester/index.ts
@@ -1,0 +1,3 @@
+export { RequesterProvider, useRequester, REQUESTER_STORAGE_KEY } from "./RequesterContext.js";
+export { default as RequesterSelector } from "./RequesterSelector.js";
+export { default as RequireRequester } from "./RequireRequester.js";

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,11 +1,19 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import App from "../../src/App.js";
+import SystemCheck from "../../src/SystemCheck.js";
+import { AppShell } from "../../src/components/index.js";
 
 // These tests mock at the `fetch` level rather than mocking checkSystem, so the
 // real api.ts runs — including its error translation. Mocking checkSystem would
 // skip that module entirely and leave the translation untested.
+//
+// UPDATED IN LAB 2 (Issue #20). App.tsx became the router, so the Lab 1 screen
+// now lives in src/SystemCheck.tsx and these tests render it directly. Nothing
+// about the screen's markup, behaviour or assertions changed — only the import
+// and the element under test. It is rendered inside AppShell because that is
+// where the TokTickIT identity has lived since Issue #18, and this test
+// asserts on it.
 afterEach(() => vi.restoreAllMocks());
 
 const SEEDED = [
@@ -34,10 +42,14 @@ function mockFetch(routes: { health?: unknown; categories?: unknown }) {
   return fetchMock;
 }
 
-describe("App", () => {
+describe("System check screen", () => {
   // UI-01
   it("renders the TokTickIT heading", () => {
-    render(<App />);
+    render(
+      <AppShell>
+        <SystemCheck />
+      </AppShell>,
+    );
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
@@ -45,7 +57,11 @@ describe("App", () => {
   it("shows Online and the seeded categories on success", async () => {
     const fetchMock = mockFetch({});
 
-    render(<App />);
+    render(
+      <AppShell>
+        <SystemCheck />
+      </AppShell>,
+    );
     await userEvent.click(screen.getByRole("button", { name: /check system/i }));
 
     expect(await screen.findByText("Online")).toBeInTheDocument();
@@ -72,7 +88,11 @@ describe("App", () => {
     // What the browser actually throws when the server is not running.
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
 
-    render(<App />);
+    render(
+      <AppShell>
+        <SystemCheck />
+      </AppShell>,
+    );
     await userEvent.click(screen.getByRole("button", { name: /check system/i }));
 
     expect(await screen.findByText("Offline")).toBeInTheDocument();
@@ -86,7 +106,11 @@ describe("App", () => {
   it("shows Offline when the categories endpoint returns an error status", async () => {
     mockFetch({ categories: jsonResponse({ error: "Could not load categories." }, 500) });
 
-    render(<App />);
+    render(
+      <AppShell>
+        <SystemCheck />
+      </AppShell>,
+    );
     await userEvent.click(screen.getByRole("button", { name: /check system/i }));
 
     expect(await screen.findByText("Offline")).toBeInTheDocument();

--- a/client/tests/lab-02/RequesterRouteGuard.test.tsx
+++ b/client/tests/lab-02/RequesterRouteGuard.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import App from "../../src/App.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/requester/index.js";
+
+// UI-02 — AC-02. A requester-scoped route opened directly must show the
+// selector, and must not fetch or render any ticket data on the way.
+
+const REQUESTERS = [{ id: 1, fullName: "Nadia Rahman", email: "nadia.rahman@toktickit.local" }];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+function mockFetch(body: unknown = REQUESTERS) {
+  const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => body }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+describe("requester route guard", () => {
+  it.each(["/tickets", "/create"])("sends an unselected visitor at %s to the selector", async (path) => {
+    mockFetch();
+    renderAt(path);
+
+    expect(
+      await screen.findByRole("heading", { name: "Development Requester Selection" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "My Tickets" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Create Ticket" })).not.toBeInTheDocument();
+  });
+
+  it("hides the requester navigation until a requester is chosen", async () => {
+    mockFetch();
+    renderAt("/tickets");
+
+    await screen.findByRole("heading", { name: "Development Requester Selection" });
+    expect(screen.queryByRole("button", { name: "My Tickets" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Change Requester" })).not.toBeInTheDocument();
+  });
+
+  it("restores a stored requester and lets the guarded route render", async () => {
+    window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+    mockFetch();
+    renderAt("/tickets");
+
+    expect(await screen.findByRole("heading", { name: "My Tickets" })).toBeInTheDocument();
+    // The name appears in the shell banner and again in the page body.
+    expect(screen.getAllByText("Nadia Rahman").length).toBeGreaterThan(0);
+  });
+
+  it("drops a stored requester who is no longer active", async () => {
+    // BR-06: a requester deactivated since the id was stored must not remain the
+    // context. The API no longer lists them, so the stored claim resolves to
+    // nothing and is discarded.
+    window.localStorage.setItem(REQUESTER_STORAGE_KEY, "999");
+    mockFetch();
+    renderAt("/tickets");
+
+    expect(
+      await screen.findByRole("heading", { name: "Development Requester Selection" }),
+    ).toBeInTheDocument();
+    expect(window.localStorage.getItem(REQUESTER_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not bounce a returning requester while the stored id is being resolved", async () => {
+    window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+    mockFetch();
+    renderAt("/tickets");
+
+    // Before resolution completes the guard must wait, not redirect.
+    expect(screen.getByRole("status")).toHaveTextContent(/Restoring your Development Requester/i);
+    expect(
+      screen.queryByRole("heading", { name: "Development Requester Selection" }),
+    ).not.toBeInTheDocument();
+
+    expect(await screen.findByRole("heading", { name: "My Tickets" })).toBeInTheDocument();
+  });
+});

--- a/client/tests/lab-02/RequesterSelector.test.tsx
+++ b/client/tests/lab-02/RequesterSelector.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import App from "../../src/App.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/requester/index.js";
+
+// UI-01 — AC-01. The selector offers active requesters, says what it is, and
+// handles loading, empty and failure.
+
+const REQUESTERS = [
+  { id: 3, fullName: "Marisa Chen", email: "marisa.chen@toktickit.local" },
+  { id: 1, fullName: "Nadia Rahman", email: "nadia.rahman@toktickit.local" },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+/**
+ * Routes each endpoint to its own response. Never a blanket `fetch` stub: a
+ * single mock answering every URL is a suite that cannot fail, which is the
+ * defect this project has already reviewed once on a partner PR.
+ */
+function mockFetch(handler: (url: string) => unknown) {
+  const fetchMock = vi.fn(async (url: string) => {
+    const body = handler(String(url));
+    if (body instanceof Error) throw body;
+    return { ok: true, status: 200, json: async () => body };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function renderApp(initialPath = "/select-requester") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+describe("Development Requester selection", () => {
+  it("states plainly that it is not a login screen", async () => {
+    mockFetch(() => REQUESTERS);
+    renderApp();
+
+    expect(
+      await screen.findByText(/This is not a login screen and provides no security\./i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading state, then the active requesters returned by the API", async () => {
+    mockFetch(() => REQUESTERS);
+    renderApp();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading Development Requesters");
+
+    const select = await screen.findByLabelText(/Development Requester/);
+    const options = within(select).getAllByRole("option").map((option) => option.textContent);
+    expect(options).toEqual([
+      "Choose a Development Requester",
+      "Marisa Chen — marisa.chen@toktickit.local",
+      "Nadia Rahman — nadia.rahman@toktickit.local",
+    ]);
+  });
+
+  it("keeps Continue disabled until a requester is chosen", async () => {
+    mockFetch(() => REQUESTERS);
+    renderApp();
+
+    const button = await screen.findByRole("button", { name: "Continue" });
+    expect(button).toBeDisabled();
+
+    await userEvent.selectOptions(screen.getByLabelText(/Development Requester/), "1");
+    expect(button).toBeEnabled();
+  });
+
+  it("stores only the requester id and moves on to the requester's screens", async () => {
+    mockFetch(() => REQUESTERS);
+    renderApp();
+
+    await userEvent.selectOptions(await screen.findByLabelText(/Development Requester/), "1");
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(await screen.findByRole("heading", { name: "My Tickets" })).toBeInTheDocument();
+    // BR-07: an identifier, and nothing that resembles a credential.
+    expect(window.localStorage.getItem(REQUESTER_STORAGE_KEY)).toBe("1");
+    expect(JSON.stringify({ ...window.localStorage })).not.toMatch(/token|password|secret/i);
+  });
+
+  it("explains an empty list rather than showing an empty dropdown", async () => {
+    mockFetch(() => []);
+    renderApp();
+
+    expect(
+      await screen.findByText(/No active Development Requesters are available\./i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("offers a retry after a failure, without leaking the browser's error text", async () => {
+    let attempt = 0;
+    mockFetch(() => {
+      attempt += 1;
+      return attempt === 1 ? new TypeError("Failed to fetch") : REQUESTERS;
+    });
+    renderApp();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/could not be loaded/i);
+    expect(alert).not.toHaveTextContent(/Failed to fetch/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() => expect(screen.getByLabelText(/Development Requester/)).toBeInTheDocument());
+  });
+
+  it("shows the selected requester in the shell and clears it on Change Requester", async () => {
+    mockFetch(() => REQUESTERS);
+    renderApp();
+
+    await userEvent.selectOptions(await screen.findByLabelText(/Development Requester/), "3");
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect((await screen.findAllByText("Marisa Chen")).length).toBeGreaterThan(0);
+
+    await userEvent.click(screen.getByRole("button", { name: "Change Requester" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Development Requester Selection" }),
+    ).toBeInTheDocument();
+    expect(window.localStorage.getItem(REQUESTER_STORAGE_KEY)).toBeNull();
+    expect(screen.queryAllByText("Marisa Chen")).toHaveLength(0);
+  });
+});

--- a/client/tests/lab-02/apiClient.test.ts
+++ b/client/tests/lab-02/apiClient.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { UNREACHABLE_MESSAGE, fetchRequesters } from "../../src/api.js";
+
+// UI-12 — AC-07. The API client is the boundary where a raw browser failure has
+// to become something a person can read. If that translation moves or breaks,
+// the jargon reaches the screen.
+//
+// This is also the first `.test.ts` in the client suite: the Vitest glob only
+// matched `.test.tsx` until Issue #18 widened it, so a file like this would
+// silently never have run.
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("API client error translation", () => {
+  it("turns a network-level TypeError into a readable message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+    await expect(fetchRequesters()).rejects.toThrow(UNREACHABLE_MESSAGE);
+    await expect(fetchRequesters()).rejects.not.toThrow(/Failed to fetch/);
+  });
+
+  it("reports a non-OK HTTP response without exposing the status text", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }));
+
+    await expect(fetchRequesters()).rejects.toThrow(/Could not load Development Requesters/);
+  });
+
+  it("returns the parsed body when the request succeeds", async () => {
+    const requesters = [{ id: 1, fullName: "Nadia Rahman", email: "nadia.rahman@toktickit.local" }];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => requesters }));
+
+    await expect(fetchRequesters()).resolves.toEqual(requesters);
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -68,7 +68,7 @@ E2E rows below are not claimed runnable until it merges.
 | API-13 | API | AC-15 | Soft removal returns `200` with reason, timestamp and remover; metadata still lists the attachment; a later download returns `404`; a second removal returns `409 ATTACHMENT_ALREADY_REMOVED` without overwriting the first reason. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-14 | API | AC-13 | Downloading an active attachment returns `200`, the recorded MIME type, and a `Content-Disposition` filename that is sanitised. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | UI-01 | UI | AC-01 | The selector lists active requesters only, states that it is a testing mechanism and not a login, and renders loading, empty and failure states. | `client/tests/lab-02/RequesterSelector.test.tsx` | Planned |
-| UI-02 | UI | AC-02 | Opening a requester-scoped route with nothing selected renders the selector, and no ticket data is requested. | `client/tests/lab-02/RequesterRouteGuard.test.tsx` | Planned |
+| UI-02 | UI | AC-02 | Opening a requester-scoped route with nothing selected renders the selector, no ticket data is shown, the navigation is hidden, a stored requester who is no longer active is dropped, and a returning requester is not bounced while the stored id resolves. | `client/tests/lab-02/RequesterRouteGuard.test.tsx` | Planned |
 | UI-03 | UI | AC-03 | Create Ticket loads categories and related systems from the API and shows the selected requester as a read-only field. | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
 | UI-04 | UI | AC-05 | Invalid input renders a message beneath each offending field, the submit stays disabled while busy, and entered values survive the failed attempt. | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
 | UI-05 | UI | AC-04 | A successful create renders the returned Ticket Number and Ticket Date, and offers the next action. | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
@@ -157,6 +157,36 @@ npx playwright test e2e/lab-02
 unit, API and UI suites captured from `main` after the release merge, together with the
 Playwright run and the responsive screenshots. Test counts and file paths will be filled in
 from that run, not from a feature branch and not from memory.
+
+### Issue #20 feature-branch verification
+
+Run on `feature/20-requester-context` on 2026-08-29, before peer review:
+
+- `cd client && npm test` — 5 files, **44 tests passed** (up from 2 files / 28).
+- `cd client && npm run build` — passed.
+
+**Routing arrived with this issue.** AC-02 is a claim about opening a URL directly, so it
+needs real routes rather than a conditional render — `react-router-dom` is now a client
+dependency, and `RequireRequester` guards `/create` and `/tickets`. The guard is a route
+wrapper rather than a check inside each screen, so a screen added in #22 or #24 cannot
+forget it. It is a usability guard, not a security one: the server enforces ownership on
+every request regardless (BR-08).
+
+**Two consequences worth recording, because both touched existing tests:**
+
+1. `App.tsx` became the router, so the Lab 1 system-check screen moved to
+   `src/SystemCheck.tsx` unchanged. `tests/lab-01/App.test.tsx` now renders that component
+   inside `AppShell` — inside the shell because that is where the TokTickIT identity has
+   lived since #18, and the test asserts on it. No assertion about the screen's behaviour
+   changed.
+2. The selected requester's name deliberately appears twice — in the shell banner and in
+   the page body — so exact-text queries match both elements. The affected assertions use
+   `getAllByText`. This surfaced as three failing tests on the first run rather than as a
+   silent pass, which is the right way round.
+
+**`apiClient.test.ts` is the first `.test.ts` in the client suite.** Until #18 widened the
+Vitest glob from `*.test.tsx`, a file with that extension would never have run — so UI-12
+would have been listed as covered while never executing.
 
 ### Issue #19 feature-branch verification
 


### PR DESCRIPTION
## Summary

The Development Requester selector, the context that holds the selection, and the route
guard that keeps requester screens behind it.

- **`requester/RequesterContext.tsx`** — holds the selection, persists only the id.
- **`requester/RequesterSelector.tsx`** — the selector screen, with loading, empty, failure
  and retry states.
- **`requester/RequireRequester.tsx`** — the route guard.
- **`App.tsx`** — now the router and shell; `/create` and `/tickets` are guarded.

## Routing, because AC-02 is a claim about a URL

AC-02 says that opening a requester-scoped route directly shows the selector. That is a
statement about a real address, not about which branch of a conditional rendered, so
`react-router-dom` is now a client dependency and the guard is a route wrapper.

A wrapper rather than a check inside each screen, so the screens added in #22 and #24
cannot forget it. It is a **usability** guard, not a security one — the server enforces
ownership on every request regardless (BR-08), and this only decides what the browser draws.

## Two decisions worth a reviewer's attention

**A stored id is a claim, not a fact.** On mount the context resolves the stored id against
the live list of *active* requesters. A selection whose requester has since been deactivated
is dropped and the storage cleared (BR-06) — otherwise a requester removed from the selector
could keep operating through a stale browser entry.

**The guard waits rather than redirects while that resolution is in flight.** Redirecting
first would bounce a returning user to the selector on every page load, and the fix for that
is easy to get wrong in the other direction: rendering the guarded screen optimistically
would flash another requester's context. `RequireRequester` shows a restoring state instead,
and there is a test for exactly that intermediate moment.

Only the id is persisted (BR-07). There is no token or credential in Lab 2 to store, and
persisting the whole requester would let a stale name survive a change on the server. One
test asserts storage contains nothing resembling a credential.

## Two existing tests were touched — flagging rather than burying

1. **`App.tsx` became the router**, so the Lab 1 system-check screen moved to
   `src/SystemCheck.tsx` *unchanged*. `tests/lab-01/App.test.tsx` renders that component
   inside `AppShell`, because that is where the TokTickIT identity has lived since #18 and
   the test asserts on it. No assertion about the screen's behaviour changed — only the
   import and what is mounted.
2. **The requester name appears twice on purpose** — in the shell banner and in the page
   body — so exact-text queries match both elements. Those assertions now use
   `getAllByText`. This showed up as three failing tests on the first run rather than as a
   silent pass, which is the right way round.

## Validation

- `cd client && npm test` — 5 files, **44 tests passed** (up from 2 files / 28).
- `cd client && npm run build` — passed.

`apiClient.test.ts` is the first `.test.ts` in the client suite. Until #18 widened the Vitest
glob from `*.test.tsx`, a file with that extension would never have run — UI-12 would have
sat in the traceability table looking covered while never executing once.

## Review focus

1. Is dropping a stored selection when the requester is no longer active the right call, or
   should it keep the selection and let the server reject it?
2. `/create` and `/tickets` render a placeholder naming the issue that delivers them. Honest,
   or noise you would rather not have in the tree?
3. `react-router-dom` is a new dependency. Reasonable for AC-02, or would you rather see a
   hand-rolled route state?

Relates to #20
