### PR TITLE
Issue 22: Create Ticket screen

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-
 import { AppShell, Card, type NavItem } from "./components/index.js";
 import SystemCheck from "./SystemCheck.js";
 import { RequesterProvider, RequesterSelector, RequireRequester, useRequester } from "./requester/index.js";
+import CreateTicket from "./tickets/CreateTicket.js";
 
 // Routes, so that AC-02 — opening a requester-scoped route directly shows the
 // selector — is a real claim about a real URL rather than about which branch of
@@ -50,7 +51,7 @@ function Shell() {
           path="/create"
           element={
             <RequireRequester>
-              <ComingSoon title="Create Ticket" issue={22} />
+              <CreateTicket />
             </RequireRequester>
           }
         />

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -61,3 +61,116 @@ export async function fetchRequesters(): Promise<Requester[]> {
   }
   return (await response.json()) as Requester[];
 }
+
+// ---------------------------------------------------------------------------
+// Issue 22 — Create Ticket
+// ---------------------------------------------------------------------------
+
+export const REQUESTED_PRIORITIES = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+export type RequestedPriority = (typeof REQUESTED_PRIORITIES)[number];
+
+export interface RelatedSystem {
+  id: number;
+  name: string;
+}
+
+export interface CreatedTicket {
+  id: number;
+  ticketNumber: string;
+  ticketDate: string;
+  requester: { id: number; fullName: string };
+  category: { id: number; name: string };
+  relatedSystem: { id: number; name: string };
+  summary: string;
+  description: string;
+  requestedPriority: RequestedPriority;
+  currentStatus: string;
+}
+
+export interface NewTicket {
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  description: string;
+  requestedPriority: RequestedPriority;
+}
+
+/**
+ * Carries the server's error envelope through to the form. `fieldErrors` is
+ * what lets a server-side rule land on the field it concerns rather than as one
+ * anonymous banner — the client re-checks the same rules, but the server is the
+ * authority (BR-16) and its answer has to be displayable.
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+    readonly fieldErrors?: Record<string, string>,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+type ErrorEnvelope = {
+  error?: { code?: string; message?: string; fieldErrors?: Record<string, string> };
+};
+
+async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+  let response: Response;
+  try {
+    response = await fetch(`${API_URL}${path}`, init);
+  } catch {
+    // The browser's raw TypeError never reaches a component (BR-43).
+    throw new ApiError(UNREACHABLE_MESSAGE);
+  }
+
+  if (!response.ok) {
+    // Named rather than inferred: `typeof envelope` narrows to `null` after the
+    // initialiser, so casting to it would collapse the parsed body to `never`.
+    let envelope: ErrorEnvelope | null = null;
+    try {
+      envelope = (await response.json()) as ErrorEnvelope;
+    } catch {
+      // A non-JSON error body is itself a failure worth reporting safely.
+    }
+    throw new ApiError(
+      envelope?.error?.message ?? "The request could not be completed.",
+      envelope?.error?.code,
+      envelope?.error?.fieldErrors,
+      response.status,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function fetchCategories(): Promise<Category[]> {
+  return requestJson<Category[]>("/api/categories");
+}
+
+export async function fetchRelatedSystems(): Promise<RelatedSystem[]> {
+  return requestJson<RelatedSystem[]>("/api/related-systems");
+}
+
+/**
+ * The Requester travels in a header, never in the body (decision D-01), and the
+ * idempotency key in another — both are transport metadata rather than part of
+ * the ticket being described.
+ */
+export async function createTicket(
+  ticket: NewTicket,
+  requesterId: number,
+  idempotencyKey: string,
+): Promise<CreatedTicket> {
+  return requestJson<CreatedTicket>("/api/tickets", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Dev-Requester-Id": String(requesterId),
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify(ticket),
+  });
+}

--- a/client/src/tickets/CreateTicket.tsx
+++ b/client/src/tickets/CreateTicket.tsx
@@ -1,0 +1,362 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { Link } from "react-router-dom";
+import {
+  ApiError,
+  REQUESTED_PRIORITIES,
+  createTicket,
+  fetchCategories,
+  fetchRelatedSystems,
+  type Category,
+  type CreatedTicket,
+  type RelatedSystem,
+  type RequestedPriority,
+} from "../api.js";
+import {
+  Badge,
+  Button,
+  Card,
+  ErrorAlert,
+  Field,
+  ReadOnlyField,
+  StatusMessage,
+} from "../components/index.js";
+import { useRequester } from "../requester/index.js";
+import {
+  MAX_FILES,
+  PERMITTED_TYPE_LABEL,
+  describeRejections,
+  selectAttachments,
+} from "./attachment-selection.js";
+
+// Client-side bounds mirror BR-12 to BR-15. The server re-checks every one of
+// them and is the authority (BR-16); these exist so the user is told before a
+// round trip, and so a server rule that does fire lands on its own field.
+const SUMMARY_MIN = 5;
+const SUMMARY_MAX = 120;
+const DESCRIPTION_MIN = 20;
+const DESCRIPTION_MAX = 4000;
+
+type FormValues = {
+  categoryId: string;
+  relatedSystemId: string;
+  summary: string;
+  description: string;
+  requestedPriority: "" | RequestedPriority;
+};
+
+const EMPTY: FormValues = {
+  categoryId: "",
+  relatedSystemId: "",
+  summary: "",
+  description: "",
+  requestedPriority: "",
+};
+
+function newIdempotencyKey(): string {
+  return crypto.randomUUID();
+}
+
+export default function CreateTicket() {
+  const { requester } = useRequester();
+  const [values, setValues] = useState<FormValues>(EMPTY);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [created, setCreated] = useState<CreatedTicket | null>(null);
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<RelatedSystem[]>([]);
+  const [referenceState, setReferenceState] = useState<"loading" | "ready" | "failed">("loading");
+
+  const [files, setFiles] = useState<File[]>([]);
+  const [fileError, setFileError] = useState("");
+
+  // One key per submission attempt. It is regenerated whenever a field changes,
+  // because the server treats a reused key with a different payload as a
+  // conflict (BR-19): retrying the *same* ticket after a failure must replay,
+  // but retrying an *edited* ticket is a new ticket and needs a new key.
+  const [idempotencyKey, setIdempotencyKey] = useState(newIdempotencyKey);
+
+  async function loadReferenceData() {
+    setReferenceState("loading");
+    try {
+      const [loadedCategories, loadedSystems] = await Promise.all([
+        fetchCategories(),
+        fetchRelatedSystems(),
+      ]);
+      setCategories(loadedCategories);
+      setRelatedSystems(loadedSystems);
+      setReferenceState("ready");
+    } catch {
+      setReferenceState("failed");
+    }
+  }
+
+  useEffect(() => {
+    void loadReferenceData();
+  }, []);
+
+  function update(field: keyof FormValues, value: string) {
+    setValues((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => {
+      const { [field]: _cleared, ...rest } = current;
+      return rest;
+    });
+    setSubmitError("");
+    setIdempotencyKey(newIdempotencyKey());
+  }
+
+  function validate(): Record<string, string> {
+    const errors: Record<string, string> = {};
+    const summary = values.summary.trim();
+    const description = values.description.trim();
+
+    if (!values.categoryId) errors.categoryId = "Select a Category.";
+    if (!values.relatedSystemId) errors.relatedSystemId = "Select a Related System.";
+    if (summary.length < SUMMARY_MIN || summary.length > SUMMARY_MAX) {
+      errors.summary = `Summary must be ${SUMMARY_MIN}-${SUMMARY_MAX} characters.`;
+    }
+    if (description.length < DESCRIPTION_MIN || description.length > DESCRIPTION_MAX) {
+      errors.description = `Description must be ${DESCRIPTION_MIN}-${DESCRIPTION_MAX} characters.`;
+    }
+    if (!values.requestedPriority) errors.requestedPriority = "Select a Requested Priority.";
+
+    return errors;
+  }
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (submitting) return;
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0 || !requester) return;
+
+    setSubmitting(true);
+    setSubmitError("");
+    try {
+      const ticket = await createTicket(
+        {
+          categoryId: Number(values.categoryId),
+          relatedSystemId: Number(values.relatedSystemId),
+          summary: values.summary.trim(),
+          description: values.description.trim(),
+          requestedPriority: values.requestedPriority as RequestedPriority,
+        },
+        requester.id,
+        idempotencyKey,
+      );
+      setCreated(ticket);
+    } catch (error) {
+      // BR-42: nothing the user typed is cleared here. A field error from the
+      // server lands on its field; anything else becomes one safe message.
+      if (error instanceof ApiError) {
+        setFieldErrors(error.fieldErrors ?? {});
+        setSubmitError(error.fieldErrors ? "Some details need correcting." : error.message);
+      } else {
+        setSubmitError("The Ticket could not be created. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function createAnother() {
+    setCreated(null);
+    setValues(EMPTY);
+    setFieldErrors({});
+    setSubmitError("");
+    setFiles([]);
+    setFileError("");
+    setIdempotencyKey(newIdempotencyKey());
+  }
+
+  function chooseFiles(chosen: FileList | null) {
+    const { accepted, rejected } = selectAttachments(Array.from(chosen ?? []), files);
+    setFiles(accepted);
+    setFileError(rejected.length > 0 ? describeRejections(rejected) : "");
+  }
+
+  const ticketDate = useMemo(
+    () => (created ? new Date(created.ticketDate).toLocaleString() : "Assigned after saving"),
+    [created],
+  );
+
+  if (created) {
+    return (
+      <Card title="Ticket created" as="h1">
+        <div className="zen-status" role="status">
+          <p>
+            Your Ticket has been saved as <strong>{created.ticketNumber}</strong>, raised on{" "}
+            {ticketDate}.
+          </p>
+        </div>
+
+        <ReadOnlyField label="Ticket Number" value={created.ticketNumber} />
+        <ReadOnlyField label="Ticket Date" value={ticketDate} />
+        <ReadOnlyField label="Current Status" value={<Badge tone="success">{created.currentStatus}</Badge>} />
+
+        {files.length > 0 && (
+          <p>
+            {files.length} selected {files.length === 1 ? "file was" : "files were"} checked but{" "}
+            <strong>not uploaded</strong> — attachments are added from the Ticket Detail screen,
+            which arrives with Issue #26. Nothing has been stored, so they will need choosing again.
+          </p>
+        )}
+
+        <div className="zen-shell__nav">
+          <Link className="zen-button zen-button--primary" to="/tickets">
+            View My Tickets
+          </Link>
+          <Button variant="secondary" onClick={createAnother}>
+            Create another Ticket
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card title="Create Ticket" as="h1">
+      <p>
+        Describe the problem. TokTickIT assigns the official Ticket Number once the Ticket is
+        saved.
+      </p>
+
+      {referenceState === "loading" && <StatusMessage>Loading Categories and Related Systems…</StatusMessage>}
+
+      {referenceState === "failed" && (
+        <ErrorAlert onRetry={() => void loadReferenceData()}>
+          Categories and Related Systems could not be loaded, so a Ticket cannot be raised yet.
+        </ErrorAlert>
+      )}
+
+      {submitError && <ErrorAlert>{submitError}</ErrorAlert>}
+
+      <form onSubmit={submit} noValidate>
+        {/* System-assigned values, shown from the start so their place on the
+            screen is not a surprise once they are filled in (ui-spec.md §6). */}
+        <ReadOnlyField label="Ticket Number" value="Assigned after saving" />
+        <ReadOnlyField label="Ticket Date" value="Assigned after saving" />
+        <ReadOnlyField label="Requester" value={requester?.fullName ?? "No Requester selected"} />
+
+        <Field id="categoryId" label="Category" required error={fieldErrors.categoryId}>
+          {(control) => (
+            <select
+              {...control}
+              value={values.categoryId}
+              disabled={referenceState !== "ready"}
+              onChange={(event) => update("categoryId", event.target.value)}
+            >
+              <option value="">Select a Category</option>
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </Field>
+
+        <Field id="relatedSystemId" label="Related System" required error={fieldErrors.relatedSystemId}>
+          {(control) => (
+            <select
+              {...control}
+              value={values.relatedSystemId}
+              disabled={referenceState !== "ready"}
+              onChange={(event) => update("relatedSystemId", event.target.value)}
+            >
+              <option value="">Select a Related System</option>
+              {relatedSystems.map((system) => (
+                <option key={system.id} value={system.id}>
+                  {system.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </Field>
+
+        <Field
+          id="summary"
+          label="Ticket Summary"
+          required
+          error={fieldErrors.summary}
+          hint={`${SUMMARY_MIN}-${SUMMARY_MAX} characters. ${values.summary.trim().length} so far.`}
+        >
+          {(control) => (
+            <input
+              {...control}
+              type="text"
+              value={values.summary}
+              onChange={(event) => update("summary", event.target.value)}
+            />
+          )}
+        </Field>
+
+        <Field id="requestedPriority" label="Requested Priority" required error={fieldErrors.requestedPriority}>
+          {(control) => (
+            <select
+              {...control}
+              value={values.requestedPriority}
+              onChange={(event) => update("requestedPriority", event.target.value)}
+            >
+              <option value="">Select a Requested Priority</option>
+              {REQUESTED_PRIORITIES.map((priority) => (
+                <option key={priority} value={priority}>
+                  {priority}
+                </option>
+              ))}
+            </select>
+          )}
+        </Field>
+
+        <Field
+          id="description"
+          label="Description"
+          required
+          error={fieldErrors.description}
+          hint={`${DESCRIPTION_MIN}-${DESCRIPTION_MAX} characters. ${values.description.trim().length} so far.`}
+        >
+          {(control) => (
+            <textarea
+              {...control}
+              value={values.description}
+              onChange={(event) => update("description", event.target.value)}
+            />
+          )}
+        </Field>
+
+        <Field
+          id="attachments"
+          label="Attachments"
+          error={fileError}
+          hint={`${PERMITTED_TYPE_LABEL}, up to 5 MB each, ${MAX_FILES} files maximum. Files are checked now and uploaded from the Ticket Detail screen.`}
+        >
+          {(control) => (
+            <input
+              {...control}
+              type="file"
+              multiple
+              accept="image/jpeg,image/png,image/webp,application/pdf"
+              onChange={(event) => chooseFiles(event.target.files)}
+            />
+          )}
+        </Field>
+
+        {files.length > 0 && (
+          <ul aria-label="Selected attachments">
+            {files.map((file) => (
+              <li key={`${file.name}-${file.size}`}>
+                {file.name} ({(file.size / 1024 / 1024).toFixed(1)} MB)
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <Button type="submit" busy={submitting} busyLabel="Creating ticket…" disabled={referenceState !== "ready"}>
+          Submit Ticket
+        </Button>
+      </form>
+    </Card>
+  );
+}

--- a/client/src/tickets/CreateTicket.tsx
+++ b/client/src/tickets/CreateTicket.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   ApiError,
   REQUESTED_PRIORITIES,
@@ -36,6 +36,10 @@ const SUMMARY_MAX = 120;
 const DESCRIPTION_MIN = 20;
 const DESCRIPTION_MAX = 4000;
 
+// The order the fields appear on screen. "First invalid" has to mean first as
+// the user reads it, not first as an object happens to enumerate.
+const FIELD_ORDER = ["categoryId", "relatedSystemId", "summary", "requestedPriority", "description"] as const;
+
 type FormValues = {
   categoryId: string;
   relatedSystemId: string;
@@ -58,6 +62,8 @@ function newIdempotencyKey(): string {
 
 export default function CreateTicket() {
   const { requester } = useRequester();
+  const navigate = useNavigate();
+  const [confirmingCancel, setConfirmingCancel] = useState(false);
   const [values, setValues] = useState<FormValues>(EMPTY);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState("");
@@ -130,7 +136,10 @@ export default function CreateTicket() {
 
     const errors = validate();
     setFieldErrors(errors);
-    if (Object.keys(errors).length > 0 || !requester) return;
+    if (Object.keys(errors).length > 0 || !requester) {
+      focusFirstInvalid(errors);
+      return;
+    }
 
     setSubmitting(true);
     setSubmitError("");
@@ -153,12 +162,45 @@ export default function CreateTicket() {
       if (error instanceof ApiError) {
         setFieldErrors(error.fieldErrors ?? {});
         setSubmitError(error.fieldErrors ? "Some details need correcting." : error.message);
+        // A rule the server enforced deserves the same treatment as one the
+        // client caught: send the user straight to the field that needs fixing.
+        if (error.fieldErrors) focusFirstInvalid(error.fieldErrors);
       } else {
         setSubmitError("The Ticket could not be created. Please try again.");
       }
     } finally {
       setSubmitting(false);
     }
+  }
+
+  /**
+   * Moves focus to the first invalid control in reading order (ui-spec.md §6).
+   * Without this a screen-reader or keyboard user is told the form failed and
+   * then left wherever they were, with no way to find the offending field except
+   * by walking the whole form.
+   */
+  function focusFirstInvalid(errors: Record<string, string>) {
+    const first = FIELD_ORDER.find((field) => errors[field]);
+    if (!first) return;
+    document.getElementById(first)?.focus();
+  }
+
+  const hasUnsavedInput =
+    values.categoryId !== "" ||
+    values.relatedSystemId !== "" ||
+    values.summary.trim() !== "" ||
+    values.description.trim() !== "" ||
+    values.requestedPriority !== "" ||
+    files.length > 0;
+
+  function cancel() {
+    // Leaving without warning would throw away a half-written ticket on a
+    // mis-click. Nothing is stored yet, so the only copy is what is on screen.
+    if (hasUnsavedInput) {
+      setConfirmingCancel(true);
+      return;
+    }
+    navigate("/tickets");
   }
 
   function createAnother() {
@@ -353,9 +395,26 @@ export default function CreateTicket() {
           </ul>
         )}
 
-        <Button type="submit" busy={submitting} busyLabel="Creating ticket…" disabled={referenceState !== "ready"}>
-          Submit Ticket
-        </Button>
+        {confirmingCancel && (
+          <div className="zen-alert" role="alertdialog" aria-label="Discard this Ticket?">
+            <p>Discard this Ticket? Nothing has been saved, so the details on screen will be lost.</p>
+            <Button variant="destructive" onClick={() => navigate("/tickets")}>
+              Discard Ticket
+            </Button>
+            <Button variant="secondary" onClick={() => setConfirmingCancel(false)}>
+              Keep editing
+            </Button>
+          </div>
+        )}
+
+        <div className="zen-shell__nav">
+          <Button type="submit" busy={submitting} busyLabel="Creating ticket…" disabled={referenceState !== "ready"}>
+            Submit Ticket
+          </Button>
+          <Button variant="secondary" onClick={cancel} disabled={submitting}>
+            Cancel
+          </Button>
+        </div>
       </form>
     </Card>
   );

--- a/client/src/tickets/attachment-selection.ts
+++ b/client/src/tickets/attachment-selection.ts
@@ -1,0 +1,73 @@
+// Client-side attachment rules for the Create Ticket screen.
+//
+// These mirror the fixed labsheet constraints and BR-31 to BR-33. The server
+// re-checks all of them when the file is actually uploaded (Issue #25) — this is
+// here so the user finds out immediately rather than after a round trip, not
+// because the client is trusted to decide.
+
+export const PERMITTED_TYPES = ["image/jpeg", "image/png", "image/webp", "application/pdf"] as const;
+export const PERMITTED_TYPE_LABEL = "JPEG, PNG, WEBP or PDF";
+export const MAX_BYTES = 5 * 1024 * 1024;
+export const MAX_FILES = 5;
+
+export type RejectedFile = { name: string; reason: string };
+
+export type SelectionResult = {
+  accepted: File[];
+  rejected: RejectedFile[];
+};
+
+function formatSize(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/**
+ * Partitions a selection rather than rejecting it wholesale.
+ *
+ * A user who picks one good file and one bad one should keep the good one and be
+ * told which was refused and why — losing both, with a message that names
+ * neither, is the behaviour Part 6 asks us to demonstrate the *absence* of.
+ *
+ * `already` is the set of files kept from earlier selections, so the five-file
+ * ceiling counts the whole basket rather than each pick in isolation.
+ */
+export function selectAttachments(chosen: File[], already: File[] = []): SelectionResult {
+  const accepted = [...already];
+  const rejected: RejectedFile[] = [];
+
+  for (const file of chosen) {
+    if (!(PERMITTED_TYPES as readonly string[]).includes(file.type)) {
+      rejected.push({
+        name: file.name,
+        reason: `is not a permitted type — attach ${PERMITTED_TYPE_LABEL}`,
+      });
+      continue;
+    }
+
+    if (file.size > MAX_BYTES) {
+      rejected.push({
+        name: file.name,
+        reason: `is ${formatSize(file.size)} — the limit is 5 MB per file`,
+      });
+      continue;
+    }
+
+    // Re-picking the same file should not silently double it up.
+    if (accepted.some((kept) => kept.name === file.name && kept.size === file.size)) {
+      continue;
+    }
+
+    if (accepted.length >= MAX_FILES) {
+      rejected.push({ name: file.name, reason: `exceeds the limit of ${MAX_FILES} attachments` });
+      continue;
+    }
+
+    accepted.push(file);
+  }
+
+  return { accepted, rejected };
+}
+
+export function describeRejections(rejected: RejectedFile[]): string {
+  return rejected.map((file) => `${file.name} ${file.reason}.`).join(" ");
+}

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -203,6 +203,88 @@ describe("Create Ticket — submission", () => {
   });
 });
 
+describe("Create Ticket — focus and cancel", () => {
+  it("moves focus to the first invalid field in reading order", async () => {
+    mockApi();
+    await renderCreateTicket();
+
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    // Category is first on the screen, so that is where focus belongs — not
+    // wherever the user happened to be, and not whichever key an object
+    // enumerated first.
+    expect(screen.getByLabelText(/Category/)).toHaveFocus();
+  });
+
+  it("focuses the first field that is still invalid, not simply the first field", async () => {
+    mockApi();
+    await renderCreateTicket();
+
+    // Fix the two selects; Summary becomes the first offender.
+    await userEvent.selectOptions(screen.getByLabelText(/Category/), "2");
+    await userEvent.selectOptions(screen.getByLabelText(/Related System/), "5");
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    expect(screen.getByLabelText(/Ticket Summary/)).toHaveFocus();
+  });
+
+  it("focuses the field a server-side error names", async () => {
+    mockApi({
+      create: () => ({
+        status: 400,
+        body: {
+          error: {
+            code: "VALIDATION_FAILED",
+            message: "The Ticket could not be created.",
+            fieldErrors: { description: "Description must be 20-4000 characters." },
+          },
+        },
+      }),
+    });
+    await renderCreateTicket();
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    await screen.findByText("Description must be 20-4000 characters.");
+    expect(screen.getByLabelText(/Description/)).toHaveFocus();
+  });
+
+  it("leaves immediately when Cancel is pressed on an untouched form", async () => {
+    mockApi();
+    await renderCreateTicket();
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(await screen.findByRole("heading", { name: "My Tickets" })).toBeInTheDocument();
+  });
+
+  it("asks before discarding a part-written ticket, and can be waved off", async () => {
+    mockApi();
+    await renderCreateTicket();
+    await userEvent.type(screen.getByLabelText(/Ticket Summary/), "Half a thought");
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByRole("alertdialog", { name: /Discard this Ticket/i })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "My Tickets" })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    // Nothing typed is lost by asking.
+    expect(screen.getByLabelText(/Ticket Summary/)).toHaveValue("Half a thought");
+  });
+
+  it("discards and leaves once the discard is confirmed", async () => {
+    mockApi();
+    await renderCreateTicket();
+    await userEvent.type(screen.getByLabelText(/Ticket Summary/), "Half a thought");
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(screen.getByRole("button", { name: "Discard Ticket" }));
+
+    expect(await screen.findByRole("heading", { name: "My Tickets" })).toBeInTheDocument();
+  });
+});
+
 describe("Create Ticket — attachments", () => {
   function file(name: string, type: string, size: number) {
     const created = new File(["x"], name, { type });

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import App from "../../src/App.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/requester/index.js";
+
+// UI-03, UI-04, UI-05, UI-06 — AC-03, AC-04, AC-05, AC-07.
+
+const REQUESTERS = [{ id: 1, fullName: "Nadia Rahman", email: "nadia.rahman@toktickit.local" }];
+const CATEGORIES = [{ id: 2, name: "Network" }];
+const RELATED_SYSTEMS = [{ id: 5, name: "Campus Wi-Fi" }];
+
+const CREATED = {
+  id: 42,
+  ticketNumber: "TKT-2026-00042",
+  ticketDate: "2026-08-30T09:14:22.518Z",
+  requester: { id: 1, fullName: "Nadia Rahman" },
+  category: { id: 2, name: "Network" },
+  relatedSystem: { id: 5, name: "Campus Wi-Fi" },
+  summary: "Cannot connect to Campus Wi-Fi in Building 4",
+  description: "The laptop reports an authentication failure on the campus network every morning.",
+  requestedPriority: "HIGH",
+  currentStatus: "NEW",
+};
+
+type Handler = (url: string, init?: RequestInit) => unknown;
+
+/** Routed per endpoint — never a blanket stub that answers every URL alike. */
+function mockApi(overrides: { create?: Handler; reference?: Handler } = {}) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const target = String(url);
+    calls.push({ url: target, init });
+
+    if (target.endsWith("/api/tickets") && init?.method === "POST") {
+      const result = overrides.create ? overrides.create(target, init) : CREATED;
+      if (result instanceof Error) throw result;
+      if (result && typeof result === "object" && "status" in (result as object)) {
+        const failure = result as { status: number; body: unknown };
+        return { ok: false, status: failure.status, json: async () => failure.body };
+      }
+      return { ok: true, status: 201, json: async () => result };
+    }
+
+    if (target.endsWith("/api/requesters")) return { ok: true, status: 200, json: async () => REQUESTERS };
+    if (target.endsWith("/api/categories")) return { ok: true, status: 200, json: async () => CATEGORIES };
+    if (target.endsWith("/api/related-systems")) return { ok: true, status: 200, json: async () => RELATED_SYSTEMS };
+    throw new Error(`Unexpected request: ${target}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, calls };
+}
+
+async function renderCreateTicket() {
+  window.localStorage.setItem(REQUESTER_STORAGE_KEY, "1");
+  render(
+    <MemoryRouter initialEntries={["/create"]}>
+      <App />
+    </MemoryRouter>,
+  );
+  await screen.findByRole("heading", { name: "Create Ticket" });
+  await waitFor(() => expect(screen.getByLabelText(/Category/)).toBeEnabled());
+}
+
+async function fillValidForm() {
+  await userEvent.selectOptions(screen.getByLabelText(/Category/), "2");
+  await userEvent.selectOptions(screen.getByLabelText(/Related System/), "5");
+  await userEvent.type(screen.getByLabelText(/Ticket Summary/), CREATED.summary);
+  await userEvent.selectOptions(screen.getByLabelText(/Requested Priority/), "HIGH");
+  await userEvent.type(screen.getByLabelText(/Description/), CREATED.description);
+}
+
+beforeEach(() => {
+  vi.stubGlobal("crypto", { ...globalThis.crypto, randomUUID: () => "11111111-2222-4333-8444-555555555555" });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("Create Ticket — reference data and read-only values", () => {
+  it("loads Categories and Related Systems from the API", async () => {
+    mockApi();
+    await renderCreateTicket();
+
+    expect(within(screen.getByLabelText(/Category/)).getByRole("option", { name: "Network" })).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText(/Related System/)).getByRole("option", { name: "Campus Wi-Fi" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the Requester from context, and the system-assigned fields as pending", async () => {
+    mockApi();
+    await renderCreateTicket();
+
+    // Every field §4.4 names is present, including Ticket Date.
+    expect(screen.getAllByText("Nadia Rahman").length).toBeGreaterThan(0);
+    expect(screen.getByText("Ticket Number")).toBeInTheDocument();
+    expect(screen.getByText("Ticket Date")).toBeInTheDocument();
+    expect(screen.getAllByText("Assigned after saving")).toHaveLength(2);
+  });
+});
+
+describe("Create Ticket — validation", () => {
+  it("reports every broken field beneath its own control and sends no request", async () => {
+    const { calls } = mockApi();
+    await renderCreateTicket();
+
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    expect(await screen.findByText("Select a Category.")).toBeInTheDocument();
+    expect(screen.getByText("Select a Related System.")).toBeInTheDocument();
+    expect(screen.getByText(/Summary must be 5-120 characters\./)).toBeInTheDocument();
+    expect(screen.getByText(/Description must be 20-4000 characters\./)).toBeInTheDocument();
+    expect(screen.getByText("Select a Requested Priority.")).toBeInTheDocument();
+
+    expect(calls.filter((call) => call.init?.method === "POST")).toHaveLength(0);
+  });
+
+  it("clears a field's error as soon as that field is corrected", async () => {
+    mockApi();
+    await renderCreateTicket();
+
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+    expect(await screen.findByText("Select a Category.")).toBeInTheDocument();
+
+    await userEvent.selectOptions(screen.getByLabelText(/Category/), "2");
+    expect(screen.queryByText("Select a Category.")).not.toBeInTheDocument();
+  });
+});
+
+describe("Create Ticket — submission", () => {
+  it("sends the requester and idempotency key as headers, not in the body", async () => {
+    const { calls } = mockApi();
+    await renderCreateTicket();
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    await screen.findByRole("heading", { name: "Ticket created" });
+
+    const post = calls.find((call) => call.init?.method === "POST")!;
+    const headers = post.init!.headers as Record<string, string>;
+    expect(headers["X-Dev-Requester-Id"]).toBe("1");
+    expect(headers["Idempotency-Key"]).toMatch(/^[0-9a-f-]{36}$/);
+
+    // D-01: the body describes a Ticket and nothing else.
+    const body = JSON.parse(post.init!.body as string);
+    expect(body).not.toHaveProperty("requesterId");
+    expect(body).not.toHaveProperty("idempotencyKey");
+    expect(body.summary).toBe(CREATED.summary);
+  });
+
+  it("shows the backend Ticket Number and Ticket Date after a successful save", async () => {
+    mockApi();
+    await renderCreateTicket();
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent("TKT-2026-00042");
+    expect(screen.queryByText("Assigned after saving")).not.toBeInTheDocument();
+  });
+
+  it("keeps every entered value when the API fails, and shows no raw network text", async () => {
+    mockApi({ create: () => new TypeError("Failed to fetch") });
+    await renderCreateTicket();
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/Unable to connect to TokTickIT API/i);
+    expect(alert).not.toHaveTextContent(/Failed to fetch/);
+
+    // BR-42: nothing the user typed is lost.
+    expect(screen.getByLabelText(/Ticket Summary/)).toHaveValue(CREATED.summary);
+    expect(screen.getByLabelText(/Description/)).toHaveValue(CREATED.description);
+    expect(screen.getByLabelText(/Category/)).toHaveValue("2");
+  });
+
+  it("lands a server-side field error on the field it concerns", async () => {
+    mockApi({
+      create: () => ({
+        status: 400,
+        body: {
+          error: {
+            code: "VALIDATION_FAILED",
+            message: "The Ticket could not be created.",
+            fieldErrors: { summary: "Summary must be 5-120 characters." },
+          },
+        },
+      }),
+    });
+    await renderCreateTicket();
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    const message = await screen.findByText("Summary must be 5-120 characters.");
+    expect(message).toHaveAttribute("id", "summary-error");
+    // The field also has a character-count hint, so the description lists both ids.
+    expect(screen.getByLabelText(/Ticket Summary/).getAttribute("aria-describedby")).toContain("summary-error");
+  });
+});
+
+describe("Create Ticket — attachments", () => {
+  function file(name: string, type: string, size: number) {
+    const created = new File(["x"], name, { type });
+    Object.defineProperty(created, "size", { value: size });
+    return created;
+  }
+
+  it("keeps the valid file and names each rejected one with its reason", async () => {
+    mockApi();
+    await renderCreateTicket();
+
+    // fireEvent rather than userEvent.upload: upload() honours the input's
+    // `accept` filter and would drop payload.exe before the component ever saw
+    // it. A browser treats accept as a hint — drag-and-drop ignores it — which
+    // is exactly why this validation cannot live in the attribute.
+    fireEvent.change(screen.getByLabelText(/Attachments/), {
+      target: {
+        files: [
+          file("evidence.png", "image/png", 1024),
+          file("payload.exe", "application/x-msdownload", 2048),
+          file("huge.pdf", "application/pdf", 9 * 1024 * 1024),
+        ],
+      },
+    });
+
+    // The good one survives — losing it alongside the bad ones is the failure
+    // mode Part 6 asks us to demonstrate the absence of.
+    expect(within(screen.getByRole("list", { name: "Selected attachments" })).getByText(/evidence\.png/)).toBeInTheDocument();
+
+    const error = screen.getByText(/payload\.exe/);
+    expect(error).toHaveTextContent(/payload\.exe is not a permitted type/);
+    expect(error).toHaveTextContent(/huge\.pdf is 9\.0 MB — the limit is 5 MB/);
+  });
+
+  it("refuses a sixth file while keeping the first five", async () => {
+    mockApi();
+    await renderCreateTicket();
+
+    const six = Array.from({ length: 6 }, (_, index) => file(`shot-${index}.png`, "image/png", 1024));
+    await userEvent.upload(screen.getByLabelText(/Attachments/), six);
+
+    const list = screen.getByRole("list", { name: "Selected attachments" });
+    expect(within(list).getAllByRole("listitem")).toHaveLength(5);
+    expect(screen.getByText(/shot-5\.png exceeds the limit of 5 attachments/)).toBeInTheDocument();
+  });
+
+  it("is honest that selected files are not uploaded yet", async () => {
+    mockApi();
+    await renderCreateTicket();
+    await userEvent.upload(screen.getByLabelText(/Attachments/), [file("evidence.png", "image/png", 1024)]);
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    await screen.findByRole("heading", { name: "Ticket created" });
+    expect(screen.getByText(/not uploaded/i)).toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -163,7 +163,15 @@ from that run, not from a feature branch and not from memory.
 
 Run on `feature/22-create-ticket-screen` on 2026-08-30, before peer review:
 
-- `cd client && npm test` — 6 files, **55 tests passed** (up from 5 files / 44).
+- `cd client && npm test` — 6 files, **61 tests passed** (up from 5 files / 44).
+
+**Six of those came from review.** @Earth2509 found two places where the screen did not meet
+`ui-spec.md` §6: there was no Cancel action, and focus did not move to the first invalid
+field after a failed submit. Both were requirements this repository had written down and then
+not implemented — the spec was right and the code was behind it. Cancel now confirms before
+discarding part-written input, focus moves to the first invalid control *in reading order*
+(not whichever key an object enumerated first), and a server-side field error focuses the
+field it names.
 - `cd client && npm run build` — passed. It again caught a type error the test run did not:
   `typeof envelope` narrows to `null` after its initialiser, so the parsed error body was
   being cast to `never`. Three issues running, the build has found something `npm test`

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -159,6 +159,33 @@ unit, API and UI suites captured from `main` after the release merge, together w
 Playwright run and the responsive screenshots. Test counts and file paths will be filled in
 from that run, not from a feature branch and not from memory.
 
+### Issue #22 feature-branch verification
+
+Run on `feature/22-create-ticket-screen` on 2026-08-30, before peer review:
+
+- `cd client && npm test` — 6 files, **55 tests passed** (up from 5 files / 44).
+- `cd client && npm run build` — passed. It again caught a type error the test run did not:
+  `typeof envelope` narrows to `null` after its initialiser, so the parsed error body was
+  being cast to `never`. Three issues running, the build has found something `npm test`
+  could not.
+- Server suite re-run unchanged: 9 files, 55 tests passed.
+
+**Attachment selection is validated but not uploaded.** BR-34 puts upload after the Ticket
+exists, and the upload endpoint arrives in #25, so this screen checks the files and says
+plainly on the success panel that they were *not* stored and will need choosing again. Part 6
+still gets its evidence — one valid and one invalid file, with the valid one kept and each
+rejection named — without the screen claiming to have done something it has not.
+
+**Two test bugs of mine, both worth recording because they are easy to repeat:**
+
+1. `aria-describedby` on a field with *both* a hint and an error lists two ids, so asserting
+   equality against `"summary-error"` fails. The assertion now checks containment.
+2. `userEvent.upload()` honours the input's `accept` attribute and silently drops a
+   disallowed file, so the component never saw the invalid one and the rejection never fired.
+   The test now uses `fireEvent.change`. This is the more interesting of the two: `accept` is
+   a hint that drag-and-drop ignores, which is precisely why the validation cannot live in
+   the attribute — and a test driven through `upload()` would have quietly asserted nothing.
+
 ### Issue #21 feature-branch verification
 
 Run on `feature/21-create-ticket-api` on 2026-08-29, before peer review:


### PR DESCRIPTION
## Summary

The Create Ticket screen, wired to the guarded `/create` route. Every field §4.4 names —
Ticket Number, **Ticket Date**, Requester, Category, Related System, Ticket Summary,
Requested Priority, Description, Attachments.

Ticket Number and Ticket Date are shown as *pending* from the moment the form opens rather
than materialising only after a save, so their place on the screen is not a surprise.

## Decisions worth a reviewer's attention

**The body describes a Ticket and nothing else.** The Requester goes in `X-Dev-Requester-Id`
and the idempotency key in `Idempotency-Key` (D-01). A test asserts the POST body contains
neither `requesterId` nor `idempotencyKey`, because that separation is easy to erode later.

**`ApiError` carries the server's `fieldErrors` through to the form.** The client re-checks
BR-12…BR-15, but the server is the authority (BR-16) — so when a server rule does fire, its
message has to land on the field it concerns rather than becoming one anonymous banner.
There is a test for a server-side `summary` error appearing under the Summary field, wired
by `aria-describedby`.

**The idempotency key is regenerated whenever a field changes.** Retrying the *same* ticket
after a failure must replay against the same key; retrying an *edited* ticket is a different
ticket and would otherwise hit BR-19's conflict rule and get a `409` for no reason the user
could understand. (This is the same conclusion you reached on your PR #23 — I looked at it
again while writing this and think it is right.)

**Attachment selection is partitioned, not rejected wholesale.** One good file and one bad
one keeps the good one and names each rejection with its reason — type, size, or the
five-file ceiling. That is the behaviour Part 6 asks us to be able to show, and it is the
finding from your PR #23 pointed back at my own screen.

## Attachments are validated but not uploaded, and the screen says so

BR-34 puts upload after the Ticket exists, and the upload endpoint is Issue #25. So the
success panel states plainly that the selected files were **not** stored and will need
choosing again. Part 6 still gets its evidence without the screen claiming to have done
something it has not.

## Validation

- `cd client && npm test` — 6 files, **55 tests passed** (up from 5 / 44).
- `cd client && npm run build` — passed.
- Server suite re-run unchanged: 9 files, 55 tests.

**The build again caught a type error the tests did not** — `typeof envelope` narrows to
`null` after its initialiser, so the parsed error body was being cast to `never`. Third
issue running that `npm run build` has found something `npm test` could not; worth both of us
remembering that a green Vitest run says nothing about whether the code compiles.

## Two test bugs of mine, flagged rather than buried

1. `aria-describedby` on a field with both a hint and an error lists two ids, so asserting
   equality against `"summary-error"` failed. It now checks containment.
2. **`userEvent.upload()` honours the input's `accept` attribute** and silently dropped the
   disallowed file, so the component never saw it and the rejection never fired — the test
   passed the file in and asserted on an outcome that could not occur. It now uses
   `fireEvent.change`. This one is worth knowing generally: `accept` is a hint that
   drag-and-drop ignores, which is exactly why the validation cannot live in the attribute,
   and a test driven through `upload()` would have quietly asserted nothing.

## Review focus

1. Is regenerating the idempotency key on every field change right, or would you scope it
   per submission attempt and handle the `409` instead?
2. The success panel is deliberately blunt about attachments not being uploaded. Too blunt
   for a graded screenshot, or right?
3. Client bounds duplicate the server's. Acceptable for immediate feedback, or would you
   rather the client stayed dumb and let the server own every rule?

Relates to #22
