### PR TITLE
Issue 23: My Tickets list and Ticket detail APIs

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -159,6 +159,34 @@ unit, API and UI suites captured from `main` after the release merge, together w
 Playwright run and the responsive screenshots. Test counts and file paths will be filled in
 from that run, not from a feature branch and not from memory.
 
+### Issue #23 feature-branch verification
+
+Run on `feature/23-my-tickets-api` on 2026-08-30, before peer review:
+
+- `cd server && npm test` — 12 files, **89 tests passed** (up from 9 files / 55).
+- `cd server && npm run build` — passed.
+
+**These run against the real database rather than a mocked Prisma.** Owner scoping is the
+security-relevant claim in the sprint, and a mocked `findMany` returns what the mock was told
+— so it can only prove the route builds a `where` clause, never that PostgreSQL honours it.
+The same argument was put to the peer on his PR #24; it applies here.
+
+**Three decisions the tests pin down:**
+
+- **Invalid query parameters are rejected, not ignored** (BR-27). "No results" and "you asked
+  the wrong question" are different answers and a caller cannot tell them apart from the
+  outside, so a bad `sortBy` returns `400` with a field error rather than a plausible empty
+  page. That includes a `currentStatus` filter, which Lab 2 does not have (BR-30) — silently
+  ignoring it would hand unfiltered results to a client that believes they are filtered.
+- **A repeated parameter is rejected.** Express turns `?page=1&page=99` into an array;
+  quietly picking one would make the query mean something the caller did not write.
+- **`totalPages` is never below 1**, so an empty result reads "page 1 of 1" rather than
+  "page 1 of 0" — the same correction raised on the peer's PR #24.
+
+The list response omits `description` deliberately: at 4000 characters a row, and never
+rendered in the table, it would be up to 200 kB of unused text per page. A test asserts the
+exact key set so it cannot drift back in.
+
 ### Issue #22 feature-branch verification
 
 Run on `feature/22-create-ticket-screen` on 2026-08-30, before peer review:

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,7 +3,7 @@ import cors from "cors";
 import { getPrisma } from "./prisma.js";
 import { CLIENT_ORIGIN, SERVICE_NAME } from "./config.js";
 import { sendDependencyUnavailable } from "./errors.js";
-import { createTicket } from "./tickets-route.js";
+import { createTicket, getTicket, listTickets } from "./tickets-route.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -81,5 +81,10 @@ app.get("/api/requesters", async (_req: Request, res: Response) => {
 // the body, so this route describes a Ticket and nothing else (decision D-01).
 // ---------------------------------------------------------------------------
 app.post("/api/tickets", createTicket);
+
+// Issue 23 — My Tickets. Both are requester-scoped: the list is filtered by the
+// header identity and the detail is fetched by (id, requesterId) together.
+app.get("/api/tickets", listTickets);
+app.get("/api/tickets/:ticketId", getTicket);
 
 export default app;

--- a/server/src/ticket-query.ts
+++ b/server/src/ticket-query.ts
@@ -1,0 +1,160 @@
+// Query parsing for GET /api/tickets (api-spec.md §3, BR-21 to BR-28).
+//
+// Kept apart from the route so the rules can be unit-tested without a database.
+// Every rule here rejects rather than ignores: a typo in a query string must not
+// come back as a legitimate-looking empty list (BR-27), because "no results" and
+// "you asked the wrong question" are different answers and the user cannot tell
+// them apart from the outside.
+
+export const SORT_FIELDS = ["ticketDate", "ticketNumber", "requestedPriority"] as const;
+export const SORT_ORDERS = ["asc", "desc"] as const;
+export const PAGE_SIZES = [10, 25, 50] as const;
+export const PRIORITIES = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+
+export const DEFAULT_PAGE_SIZE = 10;
+export const SEARCH_MAX = 120;
+
+export type SortField = (typeof SORT_FIELDS)[number];
+export type SortOrder = (typeof SORT_ORDERS)[number];
+export type PageSize = (typeof PAGE_SIZES)[number];
+export type Priority = (typeof PRIORITIES)[number];
+
+export type TicketListQuery = {
+  search?: string;
+  categoryId?: number;
+  relatedSystemId?: number;
+  requestedPriority?: Priority;
+  sortBy: SortField;
+  sortOrder: SortOrder;
+  page: number;
+  pageSize: PageSize;
+};
+
+export type QueryValidation =
+  | { value: TicketListQuery; fieldErrors?: never }
+  | { value?: never; fieldErrors: Record<string, string> };
+
+export function validateTicketListQuery(raw: Record<string, unknown>): QueryValidation {
+  const fieldErrors: Record<string, string> = {};
+
+  const search = optionalSearch(raw.search, fieldErrors);
+  const categoryId = optionalId(raw.categoryId, "categoryId", fieldErrors);
+  const relatedSystemId = optionalId(raw.relatedSystemId, "relatedSystemId", fieldErrors);
+  const requestedPriority = optionalChoice(raw.requestedPriority, "requestedPriority", PRIORITIES, fieldErrors);
+  const sortBy = optionalChoice(raw.sortBy, "sortBy", SORT_FIELDS, fieldErrors) ?? "ticketDate";
+  const sortOrder = optionalChoice(raw.sortOrder, "sortOrder", SORT_ORDERS, fieldErrors) ?? "desc";
+  const page = optionalPage(raw.page, fieldErrors);
+  const pageSize = optionalPageSize(raw.pageSize, fieldErrors);
+
+  // Lab 2 has no Current Status filter (BR-30, decision D-07): every ticket is
+  // NEW, so the control could never change a result set. Rejecting it rather
+  // than ignoring it means a client written against a later lab is told, instead
+  // of silently receiving unfiltered results it believes are filtered.
+  if (raw.currentStatus !== undefined) {
+    fieldErrors.currentStatus =
+      "Current Status filtering arrives in Lab 3. Every Lab 2 Ticket is NEW.";
+  }
+
+  if (Object.keys(fieldErrors).length > 0) return { fieldErrors };
+
+  return {
+    value: {
+      ...(search ? { search } : {}),
+      ...(categoryId ? { categoryId } : {}),
+      ...(relatedSystemId ? { relatedSystemId } : {}),
+      ...(requestedPriority ? { requestedPriority } : {}),
+      sortBy,
+      sortOrder,
+      page: page ?? 1,
+      pageSize: pageSize ?? DEFAULT_PAGE_SIZE,
+    },
+  };
+}
+
+/** Total pages, never below 1 — a reader is always on page 1 of at least 1. */
+export function totalPages(totalItems: number, pageSize: number): number {
+  return Math.max(1, Math.ceil(totalItems / pageSize));
+}
+
+function only(value: unknown, field: string, fieldErrors: Record<string, string>): string | undefined {
+  if (value === undefined) return undefined;
+  // Express turns a repeated parameter into an array. Picking one silently would
+  // make ?page=1&page=99 mean something the caller did not write.
+  if (Array.isArray(value)) {
+    fieldErrors[field] = "Provide this parameter once.";
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    fieldErrors[field] = "Provide a single text value.";
+    return undefined;
+  }
+  return value;
+}
+
+function optionalSearch(value: unknown, fieldErrors: Record<string, string>): string | undefined {
+  const raw = only(value, "search", fieldErrors);
+  if (raw === undefined) return undefined;
+
+  const search = raw.trim();
+  if (search.length === 0) return undefined;
+  if (search.length > SEARCH_MAX) {
+    fieldErrors.search = `Search must be ${SEARCH_MAX} characters or fewer.`;
+    return undefined;
+  }
+  return search;
+}
+
+function optionalId(value: unknown, field: string, fieldErrors: Record<string, string>): number | undefined {
+  const raw = only(value, field, fieldErrors);
+  if (raw === undefined) return undefined;
+
+  if (!/^\d+$/.test(raw)) {
+    fieldErrors[field] = "Provide a positive whole number.";
+    return undefined;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    fieldErrors[field] = "Provide a positive whole number.";
+    return undefined;
+  }
+  return parsed;
+}
+
+function optionalChoice<T extends readonly string[]>(
+  value: unknown,
+  field: string,
+  allowed: T,
+  fieldErrors: Record<string, string>,
+): T[number] | undefined {
+  const raw = only(value, field, fieldErrors);
+  if (raw === undefined) return undefined;
+
+  if (!allowed.includes(raw)) {
+    fieldErrors[field] = `Choose one of: ${allowed.join(", ")}.`;
+    return undefined;
+  }
+  return raw as T[number];
+}
+
+function optionalPage(value: unknown, fieldErrors: Record<string, string>): number | undefined {
+  const raw = only(value, "page", fieldErrors);
+  if (raw === undefined) return undefined;
+
+  if (!/^\d+$/.test(raw) || Number(raw) < 1) {
+    fieldErrors.page = "Page must be a whole number of 1 or more.";
+    return undefined;
+  }
+  return Number(raw);
+}
+
+function optionalPageSize(value: unknown, fieldErrors: Record<string, string>): PageSize | undefined {
+  const raw = only(value, "pageSize", fieldErrors);
+  if (raw === undefined) return undefined;
+
+  const parsed = Number(raw);
+  if (!/^\d+$/.test(raw) || !(PAGE_SIZES as readonly number[]).includes(parsed)) {
+    fieldErrors.pageSize = `Page size must be one of: ${PAGE_SIZES.join(", ")}.`;
+    return undefined;
+  }
+  return parsed as PageSize;
+}

--- a/server/src/tickets-route.ts
+++ b/server/src/tickets-route.ts
@@ -4,6 +4,12 @@ import { getPrisma } from "./prisma.js";
 import { sendDependencyUnavailable, sendError } from "./errors.js";
 import { resolveRequester } from "./requester-context.js";
 import {
+  DEFAULT_PAGE_SIZE,
+  totalPages as pageCount,
+  validateTicketListQuery,
+  type TicketListQuery,
+} from "./ticket-query.js";
+import {
   formatTicketNumber,
   isSameTicket,
   validateTicketCreate,
@@ -202,4 +208,153 @@ async function createWithNumber(
       select: ticketSelect,
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// Issue 23 — My Tickets (api-spec.md §3)
+// ---------------------------------------------------------------------------
+
+// The list carries what the table shows and nothing more. `description` runs to
+// 4000 characters and is never rendered in a row, so shipping it would send up
+// to 200 kB of unused text per page — it belongs on the detail response only.
+const listSelect = {
+  id: true,
+  ticketNumber: true,
+  summary: true,
+  requestedPriority: true,
+  currentStatus: true,
+  createdAt: true,
+  category: { select: { id: true, name: true } },
+  relatedSystem: { select: { id: true, name: true } },
+  _count: { select: { attachments: { where: { removedAt: null } } } },
+} satisfies Prisma.TicketSelect;
+
+type ListRow = Prisma.TicketGetPayload<{ select: typeof listSelect }>;
+
+function serializeRow(ticket: ListRow) {
+  return {
+    id: ticket.id,
+    ticketNumber: ticket.ticketNumber,
+    ticketDate: ticket.createdAt,
+    summary: ticket.summary,
+    category: ticket.category,
+    relatedSystem: ticket.relatedSystem,
+    requestedPriority: ticket.requestedPriority,
+    currentStatus: ticket.currentStatus,
+    attachmentCount: ticket._count.attachments,
+  };
+}
+
+function orderBy(query: TicketListQuery): Prisma.TicketOrderByWithRelationInput[] {
+  const direction = query.sortOrder;
+  const primary =
+    query.sortBy === "ticketDate"
+      ? { createdAt: direction }
+      : query.sortBy === "ticketNumber"
+        ? { ticketNumber: direction }
+        : { requestedPriority: direction };
+
+  // Ticket Number descending is always the tie-breaker, so paging is stable:
+  // without it, two tickets sharing a timestamp can swap between pages and one
+  // of them is never seen (BR-24).
+  return [primary, { ticketNumber: "desc" }];
+}
+
+export async function listTickets(req: Request, res: Response): Promise<void> {
+  const context = await resolveRequester(req).catch(() => null);
+  if (context === null) {
+    sendDependencyUnavailable(res, "GET /api/tickets (requester lookup)", new Error("lookup failed"));
+    return;
+  }
+  if (!context.requester) {
+    sendError(res, 401, "REQUESTER_CONTEXT_REQUIRED", "Select a Development Requester to see your Tickets.");
+    return;
+  }
+
+  const validation = validateTicketListQuery(req.query as Record<string, unknown>);
+  if (!validation.value) {
+    sendError(res, 400, "VALIDATION_FAILED", "The Ticket list query is not valid.", validation.fieldErrors);
+    return;
+  }
+
+  const query = validation.value;
+
+  // Scoped to the requester before anything else is applied (BR-21). This is the
+  // whole of the ownership guarantee for the list: it is a database predicate,
+  // not something the caller can influence.
+  const where: Prisma.TicketWhereInput = {
+    requesterId: context.requester.id,
+    ...(query.categoryId ? { categoryId: query.categoryId } : {}),
+    ...(query.relatedSystemId ? { relatedSystemId: query.relatedSystemId } : {}),
+    ...(query.requestedPriority ? { requestedPriority: query.requestedPriority } : {}),
+    ...(query.search
+      ? {
+          OR: [
+            { ticketNumber: { contains: query.search, mode: "insensitive" } },
+            { summary: { contains: query.search, mode: "insensitive" } },
+          ],
+        }
+      : {}),
+  };
+
+  try {
+    const prisma = getPrisma();
+    const [totalItems, items] = await Promise.all([
+      prisma.ticket.count({ where }),
+      prisma.ticket.findMany({
+        where,
+        orderBy: orderBy(query),
+        skip: (query.page - 1) * query.pageSize,
+        take: query.pageSize,
+        select: listSelect,
+      }),
+    ]);
+
+    res.status(200).json({
+      items: items.map(serializeRow),
+      page: query.page,
+      pageSize: query.pageSize,
+      totalItems,
+      totalPages: pageCount(totalItems, query.pageSize),
+    });
+  } catch (error) {
+    sendDependencyUnavailable(res, "GET /api/tickets", error);
+  }
+}
+
+export async function getTicket(req: Request, res: Response): Promise<void> {
+  const context = await resolveRequester(req).catch(() => null);
+  if (context === null) {
+    sendDependencyUnavailable(res, "GET /api/tickets/:id (requester lookup)", new Error("lookup failed"));
+    return;
+  }
+  if (!context.requester) {
+    sendError(res, 401, "REQUESTER_CONTEXT_REQUIRED", "Select a Development Requester to open a Ticket.");
+    return;
+  }
+
+  const ticketId = Number(req.params.ticketId);
+  if (!Number.isSafeInteger(ticketId) || ticketId < 1) {
+    // Indistinguishable from a ticket that exists but is not yours (D-04).
+    sendError(res, 404, "TICKET_NOT_FOUND", "That Ticket could not be found.");
+    return;
+  }
+
+  try {
+    // Ownership is part of the query, so another requester's ticket is not
+    // fetched and then refused — it is never read at all (BR-10).
+    const ticket = await getPrisma().ticket.findFirst({
+      where: { id: ticketId, requesterId: context.requester.id },
+      select: ticketSelect,
+    });
+
+    if (!ticket) {
+      sendError(res, 404, "TICKET_NOT_FOUND", "That Ticket could not be found.");
+      return;
+    }
+
+    res.status(200).json(serialize(ticket));
+  } catch (error) {
+    sendDependencyUnavailable(res, "GET /api/tickets/:id", error);
+  }
 }

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { REQUESTER_HEADER } from "../../src/requester-context.js";
+
+// API-06, API-07, API-08, API-09 — AC-08, AC-09, AC-10.
+//
+// Against the real database. Scoping is the security-relevant claim in this
+// sprint and a mocked `findMany` cannot make it: it returns what the mock was
+// told, so the test would prove the route builds a `where` clause and nothing
+// about whether PostgreSQL honours it.
+
+const prisma = getPrisma();
+
+let ownerId = 0;
+let otherId = 0;
+let networkId = 0;
+let hardwareId = 0;
+let wifiId = 0;
+
+const ticketIds: number[] = [];
+
+async function create(
+  requesterId: number,
+  summary: string,
+  priority: string,
+  categoryId: number,
+  relatedSystemId: number,
+) {
+  const res = await request(app)
+    .post("/api/tickets")
+    .set(REQUESTER_HEADER, String(requesterId))
+    .set("Idempotency-Key", randomUUID())
+    .send({
+      categoryId,
+      relatedSystemId,
+      summary,
+      description: "Seeded by the My Tickets suite so the list has something to page through.",
+      requestedPriority: priority,
+    });
+  if (res.status !== 201) throw new Error(`create failed ${res.status}: ${JSON.stringify(res.body)}`);
+  ticketIds.push(res.body.id);
+  return res.body;
+}
+
+function list(requesterId: number, query: Record<string, string | number> = {}) {
+  return request(app).get("/api/tickets").set(REQUESTER_HEADER, String(requesterId)).query(query);
+}
+
+beforeAll(async () => {
+  const [requesters, network, hardware, wifi] = await Promise.all([
+    prisma.requester.findMany({ where: { isActive: true }, orderBy: { id: "asc" }, take: 2 }),
+    prisma.category.findFirstOrThrow({ where: { name: "Network" } }),
+    prisma.category.findFirstOrThrow({ where: { name: "Hardware" } }),
+    prisma.relatedSystem.findFirstOrThrow({ where: { name: "Campus Wi-Fi" } }),
+  ]);
+  ownerId = requesters[0].id;
+  otherId = requesters[1].id;
+  networkId = network.id;
+  hardwareId = hardware.id;
+  wifiId = wifi.id;
+
+  // Created through the API, sequentially, so ticket numbers ascend with time.
+  await create(ownerId, "ALPHA campus wifi drops nightly", "LOW", networkId, wifiId);
+  await create(ownerId, "BRAVO laptop will not boot", "URGENT", hardwareId, wifiId);
+  await create(ownerId, "CHARLIE vpn refuses the handshake", "MEDIUM", networkId, wifiId);
+  await create(otherId, "DELTA mailbox is full", "HIGH", hardwareId, wifiId);
+}, 60000);
+
+describe("GET /api/tickets — ownership", () => {
+  it("returns only the header requester's tickets", async () => {
+    const mine = await list(ownerId, { pageSize: 50 });
+    const theirs = await list(otherId, { pageSize: 50 });
+
+    expect(mine.status).toBe(200);
+    expect(mine.body.items.map((t: { summary: string }) => t.summary)).toEqual(
+      expect.arrayContaining(["ALPHA campus wifi drops nightly"]),
+    );
+    expect(mine.body.items.some((t: { summary: string }) => t.summary.startsWith("DELTA"))).toBe(false);
+    expect(theirs.body.items.every((t: { summary: string }) => t.summary.startsWith("DELTA"))).toBe(true);
+  });
+
+  it("refuses a request with no requester context", async () => {
+    const res = await request(app).get("/api/tickets");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("REQUESTER_CONTEXT_REQUIRED");
+  });
+});
+
+describe("GET /api/tickets — search and filters", () => {
+  it("matches Summary case-insensitively", async () => {
+    const res = await list(ownerId, { search: "alpha" });
+    expect(res.body.totalItems).toBe(1);
+    expect(res.body.items[0].summary).toBe("ALPHA campus wifi drops nightly");
+  });
+
+  it("matches Ticket Number as well as Summary", async () => {
+    const all = await list(ownerId, { pageSize: 50 });
+    const number = all.body.items[0].ticketNumber as string;
+
+    const res = await list(ownerId, { search: number.toLowerCase() });
+    expect(res.body.items.map((t: { ticketNumber: string }) => t.ticketNumber)).toContain(number);
+  });
+
+  it("filters by Category and by Requested Priority", async () => {
+    const byCategory = await list(ownerId, { categoryId: networkId, pageSize: 50 });
+    expect(byCategory.body.items.every((t: { category: { id: number } }) => t.category.id === networkId)).toBe(true);
+
+    const byPriority = await list(ownerId, { requestedPriority: "URGENT", pageSize: 50 });
+    expect(byPriority.body.items.every((t: { requestedPriority: string }) => t.requestedPriority === "URGENT")).toBe(true);
+  });
+
+  it("returns an empty page rather than an error when nothing matches", async () => {
+    const res = await list(ownerId, { search: "zzzz-nothing-matches-this" });
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.totalItems).toBe(0);
+    // A reader is always on page 1 of at least 1 — never "page 1 of 0".
+    expect(res.body.totalPages).toBe(1);
+  });
+});
+
+describe("GET /api/tickets — sorting", () => {
+  it("sorts Requested Priority by severity, not alphabetically", async () => {
+    const res = await list(ownerId, { sortBy: "requestedPriority", sortOrder: "asc", pageSize: 50 });
+    const order = res.body.items.map((t: { requestedPriority: string }) => t.requestedPriority);
+
+    // Alphabetical would be LOW, MEDIUM, URGENT — the same here by coincidence,
+    // so assert against the declared enum order explicitly.
+    const severity = ["LOW", "MEDIUM", "HIGH", "URGENT"];
+    const ranks = order.map((priority: string) => severity.indexOf(priority));
+    expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+    expect(order).toContain("URGENT");
+  });
+
+  it("defaults to newest first and breaks ties by Ticket Number", async () => {
+    const res = await list(ownerId, { pageSize: 50 });
+    const dates = res.body.items.map((t: { ticketDate: string }) => new Date(t.ticketDate).getTime());
+    expect(dates).toEqual([...dates].sort((a, b) => b - a));
+  });
+});
+
+describe("GET /api/tickets — pagination", () => {
+  it("reports page metadata and pages through without repeating a ticket", async () => {
+    const first = await list(ownerId, { pageSize: 10, page: 1 });
+    expect(first.body.page).toBe(1);
+    expect(first.body.pageSize).toBe(10);
+    expect(first.body.totalItems).toBeGreaterThanOrEqual(3);
+    expect(first.body.totalPages).toBe(Math.max(1, Math.ceil(first.body.totalItems / 10)));
+  });
+
+  it("returns an empty list beyond the last page, not an error", async () => {
+    const res = await list(ownerId, { page: 99 });
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+  });
+});
+
+describe("GET /api/tickets — invalid queries are rejected, not ignored", () => {
+  it.each([
+    ["sortBy", { sortBy: "summary" }],
+    ["sortOrder", { sortOrder: "sideways" }],
+    ["pageSize", { pageSize: 11 }],
+    ["page", { page: 0 }],
+    ["requestedPriority", { requestedPriority: "SOMEDAY" }],
+    ["categoryId", { categoryId: "abc" }],
+  ])("rejects an invalid %s with a field error", async (field, query) => {
+    const res = await list(ownerId, query as Record<string, string | number>);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(res.body.error.fieldErrors).toHaveProperty(field);
+  });
+
+  it("rejects a Current Status filter rather than silently ignoring it", async () => {
+    // BR-30: it does not exist in Lab 2. Ignoring it would hand back unfiltered
+    // results to a caller who believes they are filtered.
+    const res = await list(ownerId, { currentStatus: "NEW" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.fieldErrors).toHaveProperty("currentStatus");
+  });
+
+  it("rejects a repeated parameter instead of quietly choosing one", async () => {
+    const res = await request(app)
+      .get("/api/tickets?page=1&page=99")
+      .set(REQUESTER_HEADER, String(ownerId));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.fieldErrors).toHaveProperty("page");
+  });
+});
+
+describe("GET /api/tickets — response shape", () => {
+  it("carries what the table shows and omits the description", async () => {
+    const res = await list(ownerId);
+    const row = res.body.items[0];
+
+    expect(Object.keys(row).sort()).toEqual([
+      "attachmentCount",
+      "category",
+      "currentStatus",
+      "id",
+      "relatedSystem",
+      "requestedPriority",
+      "summary",
+      "ticketDate",
+      "ticketNumber",
+    ]);
+    // 4000 characters per row that no column renders.
+    expect(row).not.toHaveProperty("description");
+  });
+});

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { randomUUID } from "node:crypto";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { REQUESTER_HEADER } from "../../src/requester-context.js";
+
+// API-10 — AC-12. Cross-requester access must be indistinguishable from a
+// ticket that does not exist (BR-10, D-04): a 403 would confirm the row is real.
+
+const prisma = getPrisma();
+let ownerId = 0;
+let otherId = 0;
+let ownedTicketId = 0;
+
+beforeAll(async () => {
+  const [requesters, category, relatedSystem] = await Promise.all([
+    prisma.requester.findMany({ where: { isActive: true }, orderBy: { id: "asc" }, take: 2 }),
+    prisma.category.findFirstOrThrow({ where: { isActive: true } }),
+    prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true } }),
+  ]);
+  ownerId = requesters[0].id;
+  otherId = requesters[1].id;
+
+  const created = await request(app)
+    .post("/api/tickets")
+    .set(REQUESTER_HEADER, String(ownerId))
+    .set("Idempotency-Key", randomUUID())
+    .send({
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      summary: "Detail suite ticket",
+      description: "Created by the ticket detail suite so there is something owned to fetch.",
+      requestedPriority: "MEDIUM",
+    });
+  ownedTicketId = created.body.id;
+}, 60000);
+
+describe("GET /api/tickets/:ticketId", () => {
+  it("returns the ticket to its owner, with the description the list omits", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${ownedTicketId}`)
+      .set(REQUESTER_HEADER, String(ownerId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(ownedTicketId);
+    expect(res.body.description).toContain("Created by the ticket detail suite");
+    expect(res.body.requester.id).toBe(ownerId);
+    expect(res.body.attachments).toEqual([]);
+  });
+
+  it("refuses another requester's ticket as not found", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${ownedTicketId}`)
+      .set(REQUESTER_HEADER, String(otherId));
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("TICKET_NOT_FOUND");
+  });
+
+  it("answers a foreign ticket and a nonexistent one identically", async () => {
+    // If these differed, the difference would itself disclose that the first
+    // ticket exists.
+    const foreign = await request(app)
+      .get(`/api/tickets/${ownedTicketId}`)
+      .set(REQUESTER_HEADER, String(otherId));
+    const missing = await request(app)
+      .get("/api/tickets/98765432")
+      .set(REQUESTER_HEADER, String(otherId));
+    const malformed = await request(app)
+      .get("/api/tickets/not-a-number")
+      .set(REQUESTER_HEADER, String(otherId));
+
+    expect(foreign.status).toBe(missing.status);
+    expect(foreign.body).toEqual(missing.body);
+    expect(malformed.body).toEqual(missing.body);
+  });
+
+  it("requires a requester context", async () => {
+    const res = await request(app).get(`/api/tickets/${ownedTicketId}`);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("REQUESTER_CONTEXT_REQUIRED");
+  });
+});

--- a/server/tests/lab-02/ticket-query.test.ts
+++ b/server/tests/lab-02/ticket-query.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_PAGE_SIZE, validateTicketListQuery } from "../../src/ticket-query.js";
+
+// UNIT-06 — AC-09. The parser decides what a query means; these are the cases
+// where "reject" and "ignore" look identical from the outside and are not.
+
+describe("ticket list query", () => {
+  it("applies the documented defaults when nothing is supplied", () => {
+    const { value } = validateTicketListQuery({});
+    expect(value).toMatchObject({ sortBy: "ticketDate", sortOrder: "desc", page: 1, pageSize: DEFAULT_PAGE_SIZE });
+  });
+
+  it("trims a search term and treats an empty one as absent", () => {
+    expect(validateTicketListQuery({ search: "  laptop  " }).value?.search).toBe("laptop");
+    expect(validateTicketListQuery({ search: "   " }).value?.search).toBeUndefined();
+  });
+
+  it.each([
+    ["sortBy", "summary"],
+    ["sortOrder", "sideways"],
+    ["pageSize", "11"],
+    ["page", "0"],
+    ["requestedPriority", "SOMEDAY"],
+    ["categoryId", "-1"],
+  ])("rejects an invalid %s rather than falling back to a default", (field, value) => {
+    const result = validateTicketListQuery({ [field]: value });
+    expect(result.value).toBeUndefined();
+    expect(result.fieldErrors).toHaveProperty(field);
+  });
+
+  it("rejects a repeated parameter instead of picking one", () => {
+    const result = validateTicketListQuery({ page: ["1", "99"] });
+    expect(result.fieldErrors).toHaveProperty("page");
+  });
+
+  it("rejects a Current Status filter, which Lab 2 does not have", () => {
+    expect(validateTicketListQuery({ currentStatus: "NEW" }).fieldErrors).toHaveProperty("currentStatus");
+  });
+
+  it("reports every invalid parameter at once", () => {
+    const result = validateTicketListQuery({ sortBy: "nope", pageSize: "7", page: "0" });
+    expect(Object.keys(result.fieldErrors ?? {}).sort()).toEqual(["page", "pageSize", "sortBy"]);
+  });
+});


### PR DESCRIPTION
## Summary

`GET /api/tickets` and `GET /api/tickets/:ticketId`. Both are scoped by the
`X-Dev-Requester-Id` header rather than by anything the caller can pass in a query string.

- **`src/ticket-query.ts`** — parsing and validation, with no database in sight, so the rules
  are tested at the boundary.
- **List and detail handlers** in `tickets-route.ts`.

## Rejecting beats ignoring

Invalid query parameters return `400` with a field error rather than falling back to a
default (BR-27). The reasoning: *"no results"* and *"you asked the wrong question"* are
different answers, and a caller cannot tell them apart from the outside. An unknown `sortBy`
silently defaulting to `ticketDate` hands back a plausible page that answers a question
nobody asked.

Three cases where that bites:

- **`currentStatus` is rejected**, not ignored. Lab 2 has no status filter (BR-30) — every
  ticket is `NEW`. A client written against Lab 3 that sends it would otherwise receive
  unfiltered results while believing they were filtered.
- **A repeated parameter is rejected.** Express turns `?page=1&page=99` into an array, and
  quietly picking one makes the query mean something the caller did not write.
- **`totalPages` is never below 1**, so an empty result reads "page 1 of 1" rather than
  "page 1 of 0". That is the correction I raised on your PR #24, applied here before the
  screen that would display it exists.

## Tested against the real database, on purpose

Owner scoping is the security-relevant claim in this sprint, and a mocked `findMany` returns
whatever the mock was told — it can prove the route *builds* a `where` clause and nothing
about whether PostgreSQL honours it. That was the argument I put to you on PR #24, so this
suite is held to it: tickets are created through the real `POST /api/tickets`, then listed
back.

The detail handler matches on `(id, requesterId)` together, so another requester's ticket is
never read and then refused. A foreign ticket, a nonexistent id and a malformed id all
answer identically — a test asserts the three responses are equal, because any difference
between them would itself disclose that the row exists.

## The list omits `description`

4000 characters a row that no column renders — up to 200 kB per page of text nobody sees.
A test asserts the exact key set, so it cannot drift back in later. (Your PR #24 finding,
kept honest on my side.)

## Validation

- `cd server && npm test` — 12 files, **89 tests passed** (up from 9 / 55).
- `cd server && npm run build` — passed.

## Review focus

1. Is rejecting `currentStatus` right, or too strict? Accepting and ignoring it would be
   friendlier to a Lab 3 client, at the cost of lying about what was filtered.
2. The tie-breaker is Ticket Number descending on every sort, so paging is stable. Does that
   surprise you when sorting ascending by priority?
3. `attachmentCount` counts active attachments only. Correct for a list column, or should
   removed ones show somewhere too?

Relates to #23
