### PR TITLE
Issue 24: My Tickets screen

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { AppShell, Card, type NavItem } from "./components/index.js";
 import SystemCheck from "./SystemCheck.js";
 import { RequesterProvider, RequesterSelector, RequireRequester, useRequester } from "./requester/index.js";
 import CreateTicket from "./tickets/CreateTicket.js";
+import MyTickets from "./tickets/MyTickets.js";
 
 // Routes, so that AC-02 — opening a requester-scoped route directly shows the
 // selector — is a real claim about a real URL rather than about which branch of
@@ -59,7 +60,15 @@ function Shell() {
           path="/tickets"
           element={
             <RequireRequester>
-              <ComingSoon title="My Tickets" issue={24} />
+              <MyTickets />
+            </RequireRequester>
+          }
+        />
+        <Route
+          path="/tickets/:ticketId"
+          element={
+            <RequireRequester>
+              <ComingSoon title="Ticket Detail" issue={26} />
             </RequireRequester>
           }
         />

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -174,3 +174,59 @@ export async function createTicket(
     body: JSON.stringify(ticket),
   });
 }
+
+// ---------------------------------------------------------------------------
+// Issue 24 — My Tickets
+// ---------------------------------------------------------------------------
+
+export interface TicketListItem {
+  id: number;
+  ticketNumber: string;
+  ticketDate: string;
+  summary: string;
+  category: { id: number; name: string };
+  relatedSystem: { id: number; name: string };
+  requestedPriority: RequestedPriority;
+  currentStatus: string;
+  attachmentCount: number;
+}
+
+export interface TicketListResponse {
+  items: TicketListItem[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export interface TicketListParams {
+  search?: string;
+  categoryId?: number;
+  relatedSystemId?: number;
+  requestedPriority?: RequestedPriority;
+  sortBy?: "ticketDate" | "ticketNumber" | "requestedPriority";
+  sortOrder?: "asc" | "desc";
+  page?: number;
+  pageSize?: number;
+}
+
+/**
+ * Only parameters with a value are sent. The API rejects unknown or empty ones
+ * rather than ignoring them (BR-27), so an empty filter must be absent from the
+ * query string rather than present and blank.
+ */
+export async function fetchTickets(
+  params: TicketListParams,
+  requesterId: number,
+): Promise<TicketListResponse> {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === "" || value === null) continue;
+    query.set(key, String(value));
+  }
+
+  const suffix = query.toString();
+  return requestJson<TicketListResponse>(`/api/tickets${suffix ? `?${suffix}` : ""}`, {
+    headers: { "X-Dev-Requester-Id": String(requesterId) },
+  });
+}

--- a/client/src/styles/zen-green.css
+++ b/client/src/styles/zen-green.css
@@ -410,3 +410,148 @@ body {
     width: auto;
   }
 }
+
+/* ---------------------------------------------------------------- toolbar */
+
+.zen-toolbar {
+  display: flex;
+  gap: var(--zen-space-3);
+  flex-wrap: wrap;
+  align-items: flex-end;
+  margin-bottom: var(--zen-space-4);
+  padding: var(--zen-space-4);
+  border: 1px solid var(--zen-border);
+  border-radius: var(--zen-radius);
+  background: var(--zen-page);
+}
+
+.zen-toolbar .zen-field {
+  flex: 1 1 200px;
+  margin-bottom: 0;
+}
+
+.zen-toolbar__actions {
+  display: flex;
+  gap: var(--zen-space-2);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* ---------------------------------------------------------------- table */
+
+/* The wrapper scrolls, not the page: a wide table must never make the whole
+   document scroll sideways (ui-spec.md §9). */
+.zen-table-wrap {
+  overflow-x: auto;
+}
+
+.zen-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--zen-surface);
+}
+
+.zen-table th,
+.zen-table td {
+  padding: var(--zen-space-3);
+  border-bottom: 1px solid var(--zen-border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.zen-table thead th {
+  border-bottom: 2px solid var(--zen-primary);
+  color: var(--zen-text);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.zen-table tbody tr:hover {
+  background: var(--zen-pale);
+}
+
+.zen-table a {
+  color: var(--zen-secondary);
+  font-weight: 600;
+}
+
+.zen-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---------------------------------------------------------------- pagination */
+
+.zen-pagination {
+  display: flex;
+  gap: var(--zen-space-3);
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: var(--zen-space-4);
+}
+
+.zen-pagination p {
+  margin: 0;
+  color: var(--zen-text-muted);
+}
+
+/* ---------------------------------------------------------------- mobile */
+
+@media (max-width: 767px) {
+  /* The table becomes one card per Ticket. Each cell carries its own label from
+     data-label, so a value is never orphaned from the column it belonged to. */
+  .zen-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+  }
+
+  .zen-table,
+  .zen-table tbody,
+  .zen-table tr,
+  .zen-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .zen-table tr {
+    margin-bottom: var(--zen-space-4);
+    border: 1px solid var(--zen-border);
+    border-radius: var(--zen-radius);
+    overflow: hidden;
+  }
+
+  .zen-table td {
+    display: flex;
+    gap: var(--zen-space-3);
+    justify-content: space-between;
+    border-bottom: 1px solid var(--zen-border);
+  }
+
+  .zen-table td::before {
+    content: attr(data-label);
+    color: var(--zen-text-muted);
+    font-weight: 700;
+    flex: 0 0 45%;
+  }
+
+  .zen-table td:last-child {
+    border-bottom: 0;
+  }
+
+  .zen-pagination {
+    justify-content: center;
+    text-align: center;
+  }
+}

--- a/client/src/tickets/MyTickets.tsx
+++ b/client/src/tickets/MyTickets.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import {
+  REQUESTED_PRIORITIES,
+  fetchCategories,
+  fetchRelatedSystems,
+  fetchTickets,
+  type Category,
+  type RelatedSystem,
+  type RequestedPriority,
+  type TicketListResponse,
+} from "../api.js";
+import { Badge, Button, Card, EmptyState, ErrorAlert, Field, StatusMessage } from "../components/index.js";
+import { useRequester } from "../requester/index.js";
+
+type SortChoice =
+  | "ticketDate:desc"
+  | "ticketDate:asc"
+  | "ticketNumber:desc"
+  | "ticketNumber:asc"
+  | "requestedPriority:desc"
+  | "requestedPriority:asc";
+
+type Filters = {
+  search: string;
+  categoryId: string;
+  relatedSystemId: string;
+  requestedPriority: "" | RequestedPriority;
+  sort: SortChoice;
+};
+
+const DEFAULTS: Filters = {
+  search: "",
+  categoryId: "",
+  relatedSystemId: "",
+  requestedPriority: "",
+  sort: "ticketDate:desc",
+};
+
+const PAGE_SIZE = 10;
+
+// Typing is not a request. Without this every keystroke is a round trip and the
+// table is torn down and rebuilt under the user's hands — the behaviour found on
+// the peer's My Tickets screen, where "laptop" cost six requests.
+const SEARCH_DEBOUNCE_MS = 300;
+
+const PRIORITY_TONE: Record<RequestedPriority, "neutral" | "warning" | "danger"> = {
+  LOW: "neutral",
+  MEDIUM: "neutral",
+  HIGH: "warning",
+  URGENT: "danger",
+};
+
+export default function MyTickets() {
+  const { requester } = useRequester();
+  const navigate = useNavigate();
+
+  const [filters, setFilters] = useState<Filters>(DEFAULTS);
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<RelatedSystem[]>([]);
+
+  const [results, setResults] = useState<TicketListResponse | null>(null);
+  const [state, setState] = useState<"loading" | "ready" | "failed">("loading");
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([fetchCategories(), fetchRelatedSystems()])
+      .then(([loadedCategories, loadedSystems]) => {
+        if (!active) return;
+        setCategories(loadedCategories);
+        setRelatedSystems(loadedSystems);
+      })
+      .catch(() => {
+        // The filters degrade to "all" rather than blocking the list.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(filters.search.trim()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [filters.search]);
+
+  const [sortBy, sortOrder] = filters.sort.split(":") as [
+    "ticketDate" | "ticketNumber" | "requestedPriority",
+    "asc" | "desc",
+  ];
+
+  useEffect(() => {
+    if (!requester) return;
+    let active = true;
+    setState("loading");
+
+    fetchTickets(
+      {
+        ...(debouncedSearch ? { search: debouncedSearch } : {}),
+        ...(filters.categoryId ? { categoryId: Number(filters.categoryId) } : {}),
+        ...(filters.relatedSystemId ? { relatedSystemId: Number(filters.relatedSystemId) } : {}),
+        ...(filters.requestedPriority ? { requestedPriority: filters.requestedPriority } : {}),
+        sortBy,
+        sortOrder,
+        page,
+        pageSize: PAGE_SIZE,
+      },
+      requester.id,
+    )
+      .then((response) => {
+        // Guards against a slow response from an abandoned query overwriting a
+        // newer one — the requests are cheap, the ordering is not guaranteed.
+        if (!active) return;
+        setResults(response);
+        setState("ready");
+      })
+      .catch(() => {
+        if (active) setState("failed");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    requester,
+    debouncedSearch,
+    filters.categoryId,
+    filters.relatedSystemId,
+    filters.requestedPriority,
+    sortBy,
+    sortOrder,
+    page,
+    reloadToken,
+  ]);
+
+  function update(patch: Partial<Filters>) {
+    setFilters((current) => ({ ...current, ...patch }));
+    setPage(1);
+  }
+
+  // Every control the button resets counts towards whether it is enabled. If
+  // `sort` is cleared by it, changing only `sort` has to enable it — otherwise
+  // the button silently refuses to do something it claims to do.
+  const filtersAreDefault =
+    filters.search === DEFAULTS.search &&
+    filters.categoryId === DEFAULTS.categoryId &&
+    filters.relatedSystemId === DEFAULTS.relatedSystemId &&
+    filters.requestedPriority === DEFAULTS.requestedPriority &&
+    filters.sort === DEFAULTS.sort;
+
+  const hasQuery =
+    debouncedSearch !== "" ||
+    filters.categoryId !== "" ||
+    filters.relatedSystemId !== "" ||
+    filters.requestedPriority !== "";
+
+  function clearFilters() {
+    setFilters(DEFAULTS);
+    setDebouncedSearch("");
+    setPage(1);
+  }
+
+  const first = results && results.totalItems > 0 ? (results.page - 1) * results.pageSize + 1 : 0;
+  // Derived from the rows actually returned, not from page x pageSize, so the
+  // label stays true if the server ever returns a short page.
+  const last = results ? first + results.items.length - 1 : 0;
+
+  return (
+    <Card title="My Tickets" as="h1">
+      <div className="zen-toolbar" role="search">
+        <Field id="search" label="Search">
+          {(control) => (
+            <input
+              {...control}
+              type="search"
+              placeholder="Ticket Number or Summary"
+              value={filters.search}
+              onChange={(event) => update({ search: event.target.value })}
+            />
+          )}
+        </Field>
+
+        <Field id="categoryId" label="Category">
+          {(control) => (
+            <select {...control} value={filters.categoryId} onChange={(event) => update({ categoryId: event.target.value })}>
+              <option value="">All Categories</option>
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </Field>
+
+        <Field id="relatedSystemId" label="Related System">
+          {(control) => (
+            <select
+              {...control}
+              value={filters.relatedSystemId}
+              onChange={(event) => update({ relatedSystemId: event.target.value })}
+            >
+              <option value="">All Related Systems</option>
+              {relatedSystems.map((system) => (
+                <option key={system.id} value={system.id}>
+                  {system.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </Field>
+
+        <Field id="requestedPriority" label="Requested Priority">
+          {(control) => (
+            <select
+              {...control}
+              value={filters.requestedPriority}
+              onChange={(event) => update({ requestedPriority: event.target.value as "" | RequestedPriority })}
+            >
+              <option value="">All Priorities</option>
+              {REQUESTED_PRIORITIES.map((priority) => (
+                <option key={priority} value={priority}>
+                  {priority}
+                </option>
+              ))}
+            </select>
+          )}
+        </Field>
+
+        {/* No Current Status filter: every Lab 2 Ticket is NEW, so the control
+            could never change a result set (BR-30). The API rejects it too. */}
+        <Field id="sort" label="Sort">
+          {(control) => (
+            <select {...control} value={filters.sort} onChange={(event) => update({ sort: event.target.value as SortChoice })}>
+              <option value="ticketDate:desc">Newest first</option>
+              <option value="ticketDate:asc">Oldest first</option>
+              <option value="ticketNumber:desc">Ticket Number, high to low</option>
+              <option value="ticketNumber:asc">Ticket Number, low to high</option>
+              <option value="requestedPriority:desc">Priority, urgent first</option>
+              <option value="requestedPriority:asc">Priority, low first</option>
+            </select>
+          )}
+        </Field>
+
+        <div className="zen-toolbar__actions">
+          <Button variant="tertiary" onClick={clearFilters} disabled={filtersAreDefault}>
+            Clear filters
+          </Button>
+          <Button variant="secondary" onClick={() => setReloadToken((token) => token + 1)} disabled={state === "loading"}>
+            Refresh
+          </Button>
+          <Button onClick={() => navigate("/create")}>Create Ticket</Button>
+        </div>
+      </div>
+
+      {state === "loading" && <StatusMessage>Loading your Tickets…</StatusMessage>}
+
+      {state === "failed" && (
+        <ErrorAlert onRetry={() => setReloadToken((token) => token + 1)}>
+          Your Tickets could not be loaded.
+        </ErrorAlert>
+      )}
+
+      {state === "ready" && results && results.items.length === 0 && (
+        // Empty and no-results are different situations with different fixes.
+        // Telling someone to clear filters they never set is unhelpful (BR-29).
+        hasQuery ? (
+          <EmptyState
+            title="No Tickets match your search or filters."
+            description="Try a different term, or clear the filters to see everything."
+            action={<Button variant="secondary" onClick={clearFilters}>Clear filters</Button>}
+          />
+        ) : (
+          <EmptyState
+            title="You have not created any Tickets yet."
+            description="When you raise a Ticket it will appear here."
+            action={<Button onClick={() => navigate("/create")}>Create Ticket</Button>}
+          />
+        )
+      )}
+
+      {state === "ready" && results && results.items.length > 0 && (
+        <>
+          <div className="zen-table-wrap">
+            <table className="zen-table">
+              <caption className="zen-visually-hidden">Your Tickets</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Ticket Number</th>
+                  <th scope="col">Summary</th>
+                  <th scope="col">Category</th>
+                  <th scope="col">Related System</th>
+                  <th scope="col">Requested Priority</th>
+                  <th scope="col">Ticket Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {results.items.map((ticket) => (
+                  <tr key={ticket.id}>
+                    <td data-label="Ticket Number">
+                      <Link to={`/tickets/${ticket.id}`}>{ticket.ticketNumber}</Link>
+                    </td>
+                    <td data-label="Summary">
+                      <Link to={`/tickets/${ticket.id}`}>{ticket.summary}</Link>
+                    </td>
+                    <td data-label="Category">{ticket.category.name}</td>
+                    <td data-label="Related System">{ticket.relatedSystem.name}</td>
+                    <td data-label="Requested Priority">
+                      <Badge tone={PRIORITY_TONE[ticket.requestedPriority]}>{ticket.requestedPriority}</Badge>
+                    </td>
+                    <td data-label="Ticket Date">{new Date(ticket.ticketDate).toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <nav className="zen-pagination" aria-label="Ticket list pages">
+            <Button
+              variant="secondary"
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+              disabled={results.page <= 1}
+            >
+              Previous
+            </Button>
+
+            {/* The count, not just the page. "Page 1 of 3" alone never tells the
+                reader how many Tickets matched. */}
+            <p aria-live="polite">
+              Showing {first}–{last} of {results.totalItems}{" "}
+              {results.totalItems === 1 ? "Ticket" : "Tickets"} · Page {results.page} of {results.totalPages}
+            </p>
+
+            <Button
+              variant="secondary"
+              onClick={() => setPage((current) => Math.min(results.totalPages, current + 1))}
+              disabled={results.page >= results.totalPages}
+            >
+              Next
+            </Button>
+          </nav>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import App from "../../src/App.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/requester/index.js";
+
+// UI-07, UI-08, UI-09 — AC-08, AC-09, AC-11.
+
+const REQUESTERS = [
+  { id: 1, fullName: "Nadia Rahman", email: "nadia.rahman@toktickit.local" },
+  { id: 2, fullName: "Somchai Pattana", email: "somchai.pattana@toktickit.local" },
+];
+const CATEGORIES = [{ id: 2, name: "Network" }, { id: 3, name: "Hardware" }];
+const RELATED_SYSTEMS = [{ id: 5, name: "Campus Wi-Fi" }];
+
+function ticket(id: number, summary: string, priority = "HIGH") {
+  return {
+    id,
+    ticketNumber: `TKT-2026-${String(id).padStart(5, "0")}`,
+    ticketDate: "2026-08-30T09:00:00.000Z",
+    summary,
+    category: CATEGORIES[0],
+    relatedSystem: RELATED_SYSTEMS[0],
+    requestedPriority: priority,
+    currentStatus: "NEW",
+    attachmentCount: 0,
+  };
+}
+
+function page(items: ReturnType<typeof ticket>[], overrides: Record<string, number> = {}) {
+  return { items, page: 1, pageSize: 10, totalItems: items.length, totalPages: 1, ...overrides };
+}
+
+/** Records every /api/tickets request so query building can be asserted. */
+function mockApi(listFor: (url: URL) => unknown = () => page([ticket(1, "Campus Wi-Fi drops nightly")])) {
+  const listUrls: URL[] = [];
+  const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+    const url = new URL(String(input), "http://localhost");
+
+    if (url.pathname === "/api/tickets") {
+      listUrls.push(url);
+      const body = listFor(url);
+      if (body instanceof Error) throw body;
+      return { ok: true, status: 200, json: async () => body, headers: init?.headers };
+    }
+    if (url.pathname === "/api/requesters") return { ok: true, status: 200, json: async () => REQUESTERS };
+    if (url.pathname === "/api/categories") return { ok: true, status: 200, json: async () => CATEGORIES };
+    if (url.pathname === "/api/related-systems") return { ok: true, status: 200, json: async () => RELATED_SYSTEMS };
+    throw new Error(`Unexpected request: ${url.pathname}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, listUrls };
+}
+
+async function renderList(requesterId = "1") {
+  window.localStorage.setItem(REQUESTER_STORAGE_KEY, requesterId);
+  render(
+    <MemoryRouter initialEntries={["/tickets"]}>
+      <App />
+    </MemoryRouter>,
+  );
+  await screen.findByRole("heading", { name: "My Tickets" });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("My Tickets — the list", () => {
+  it("shows the requester's tickets with the columns the spec names", async () => {
+    mockApi();
+    await renderList();
+
+    const table = await screen.findByRole("table");
+    const headers = within(table).getAllByRole("columnheader").map((cell) => cell.textContent);
+    expect(headers).toEqual([
+      "Ticket Number",
+      "Summary",
+      "Category",
+      "Related System",
+      "Requested Priority",
+      "Ticket Date",
+    ]);
+    expect(within(table).getByText("Campus Wi-Fi drops nightly")).toBeInTheDocument();
+  });
+
+  it("sends the requester in the header, never in the query string", async () => {
+    const { listUrls } = mockApi();
+    await renderList();
+    await screen.findByRole("table");
+
+    expect(listUrls[0].searchParams.has("requesterId")).toBe(false);
+  });
+
+  it("links Ticket Number and Summary to the ticket", async () => {
+    mockApi();
+    await renderList();
+
+    const table = await screen.findByRole("table");
+    expect(within(table).getByRole("link", { name: "TKT-2026-00001" })).toHaveAttribute("href", "/tickets/1");
+    expect(within(table).getByRole("link", { name: "Campus Wi-Fi drops nightly" })).toHaveAttribute("href", "/tickets/1");
+  });
+});
+
+describe("My Tickets — searching and filtering", () => {
+  it("debounces typing into one request rather than one per keystroke", async () => {
+    const { listUrls } = mockApi();
+    await renderList();
+    await screen.findByRole("table");
+    const before = listUrls.length;
+
+    await userEvent.type(screen.getByLabelText("Search"), "laptop");
+    await waitFor(() => expect(listUrls.length).toBeGreaterThan(before), { timeout: 2000 });
+    // Let any further debounced request land before counting.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const searches = listUrls.slice(before).map((url) => url.searchParams.get("search"));
+    expect(searches.length).toBeLessThanOrEqual(2);
+    expect(searches.at(-1)).toBe("laptop");
+  });
+
+  it("omits an empty filter from the query instead of sending a blank value", async () => {
+    // The API rejects unknown or malformed parameters rather than ignoring them,
+    // so a blank filter must be absent, not present and empty.
+    const { listUrls } = mockApi();
+    await renderList();
+    await screen.findByRole("table");
+
+    const first = listUrls[0];
+    expect(first.searchParams.has("categoryId")).toBe(false);
+    expect(first.searchParams.has("search")).toBe(false);
+    expect(first.searchParams.get("sortBy")).toBe("ticketDate");
+  });
+
+  it("sends a chosen filter and resets to the first page", async () => {
+    const { listUrls } = mockApi();
+    await renderList();
+    await screen.findByRole("table");
+
+    await userEvent.selectOptions(screen.getByLabelText("Category"), "3");
+    await waitFor(() => expect(listUrls.at(-1)!.searchParams.get("categoryId")).toBe("3"));
+    expect(listUrls.at(-1)!.searchParams.get("page")).toBe("1");
+  });
+
+  it("offers no Current Status filter, because every Lab 2 Ticket is NEW", async () => {
+    mockApi();
+    await renderList();
+    await screen.findByRole("table");
+
+    expect(screen.queryByLabelText(/Current Status/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("My Tickets — Clear filters", () => {
+  it("is enabled by a sort-only change, because it resets sort too", async () => {
+    mockApi();
+    await renderList();
+    await screen.findByRole("table");
+
+    const clear = screen.getByRole("button", { name: "Clear filters" });
+    expect(clear).toBeDisabled();
+
+    await userEvent.selectOptions(screen.getByLabelText("Sort"), "ticketNumber:asc");
+    expect(clear).toBeEnabled();
+
+    await userEvent.click(clear);
+    expect(screen.getByLabelText("Sort")).toHaveValue("ticketDate:desc");
+  });
+});
+
+describe("My Tickets — empty and no-results are different", () => {
+  it("offers Create Ticket when the requester has none at all", async () => {
+    mockApi(() => page([]));
+    await renderList();
+
+    const message = await screen.findByText("You have not created any Tickets yet.");
+    // Create Ticket also sits in the toolbar, so scope to the empty panel.
+    const panel = message.closest(".zen-empty") as HTMLElement;
+    expect(within(panel).getByRole("button", { name: "Create Ticket" })).toBeInTheDocument();
+  });
+
+  it("offers Clear filters when a search matched nothing", async () => {
+    mockApi((url) => (url.searchParams.get("search") ? page([]) : page([ticket(1, "Campus Wi-Fi drops nightly")])));
+    await renderList();
+    await screen.findByRole("table");
+
+    await userEvent.type(screen.getByLabelText("Search"), "zzzz");
+
+    expect(await screen.findByText("No Tickets match your search or filters.", {}, { timeout: 3000 })).toBeInTheDocument();
+    // Telling someone to clear filters they never set would be the wrong advice,
+    // and offering "Create Ticket" here answers a question they did not ask.
+    expect(screen.queryByText("You have not created any Tickets yet.")).not.toBeInTheDocument();
+  });
+});
+
+describe("My Tickets — pagination", () => {
+  it("announces the result count, not only the page number", async () => {
+    const rows = Array.from({ length: 10 }, (_, index) => ticket(index + 1, `Ticket ${index + 1}`));
+    mockApi(() => page(rows, { totalItems: 24, totalPages: 3 }));
+    await renderList();
+    await screen.findByRole("table");
+
+    const nav = screen.getByRole("navigation", { name: "Ticket list pages" });
+    expect(nav).toHaveTextContent("Showing 1–10 of 24 Tickets");
+    expect(nav).toHaveTextContent("Page 1 of 3");
+  });
+
+  it("disables Previous on the first page and Next on the last", async () => {
+    mockApi(() => page([ticket(1, "Only ticket")]));
+    await renderList();
+    await screen.findByRole("table");
+
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+  });
+});
+
+describe("My Tickets — requester context", () => {
+  it("requests the list for whichever requester is selected", async () => {
+    const { fetchMock } = mockApi();
+    await renderList("2");
+    await screen.findByRole("table");
+
+    const listCall = fetchMock.mock.calls.find(([url]) => String(url).includes("/api/tickets"))!;
+    const headers = (listCall[1] as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Dev-Requester-Id"]).toBe("2");
+  });
+
+  it("returns to the selector when the requester is changed", async () => {
+    mockApi();
+    await renderList();
+    await screen.findByRole("table");
+
+    await userEvent.click(screen.getByRole("button", { name: "Change Requester" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Development Requester Selection" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+});

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -32,7 +32,20 @@ function page(items: ReturnType<typeof ticket>[], overrides: Record<string, numb
   return { items, page: 1, pageSize: 10, totalItems: items.length, totalPages: 1, ...overrides };
 }
 
-/** Records every /api/tickets request so query building can be asserted. */
+/** A promise the test resolves when it chooses, for loading and ordering tests. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * Records every /api/tickets request so query building can be asserted, and lets
+ * a test return a pending promise so the states between request and response are
+ * reachable rather than only their endpoints.
+ */
 function mockApi(listFor: (url: URL) => unknown = () => page([ticket(1, "Campus Wi-Fi drops nightly")])) {
   const listUrls: URL[] = [];
   const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
@@ -40,7 +53,7 @@ function mockApi(listFor: (url: URL) => unknown = () => page([ticket(1, "Campus 
 
     if (url.pathname === "/api/tickets") {
       listUrls.push(url);
-      const body = listFor(url);
+      const body = await listFor(url);
       if (body instanceof Error) throw body;
       return { ok: true, status: 200, json: async () => body, headers: init?.headers };
     }
@@ -61,6 +74,12 @@ async function renderList(requesterId = "1") {
     </MemoryRouter>,
   );
   await screen.findByRole("heading", { name: "My Tickets" });
+  // The filter dropdowns are populated by a separate request. Waiting for it here
+  // stops every test that touches a filter from racing it — which showed up as a
+  // pass in the full suite and a failure when run alone.
+  await waitFor(() =>
+    expect(within(screen.getByLabelText("Category")).getAllByRole("option").length).toBeGreaterThan(1),
+  );
 }
 
 afterEach(() => {
@@ -192,6 +211,143 @@ describe("My Tickets — empty and no-results are different", () => {
     // Telling someone to clear filters they never set would be the wrong advice,
     // and offering "Create Ticket" here answers a question they did not ask.
     expect(screen.queryByText("You have not created any Tickets yet.")).not.toBeInTheDocument();
+  });
+});
+
+describe("My Tickets — behaviour between request and response", () => {
+  it("shows the loading state, then the list it resolves to", async () => {
+    // Asked for in review: the previous tests only saw the endpoints of the
+    // request, never the state in between.
+    const gate = deferred<unknown>();
+    mockApi(() => gate.promise);
+    await renderList();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading your Tickets");
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+
+    gate.resolve(page([ticket(1, "Resolved at last")]));
+
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("Resolved at last")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("ignores a stale response that arrives after a newer one", async () => {
+    // The `active` flag exists for exactly this. Deliberate behaviour with no
+    // test is behaviour that disappears in the next refactor.
+    const gates: Array<{ resolve: (value: unknown) => void }> = [];
+    mockApi(() => {
+      const gate = deferred<unknown>();
+      gates.push(gate);
+      return gate.promise;
+    });
+    await renderList();
+
+    await userEvent.selectOptions(screen.getByLabelText("Category"), "3");
+    await waitFor(() => expect(gates.length).toBe(2));
+
+    // The newer request answers first, then the abandoned one arrives late.
+    gates[1].resolve(page([ticket(2, "Newer answer")]));
+    expect(await screen.findByText("Newer answer")).toBeInTheDocument();
+
+    gates[0].resolve(page([ticket(1, "Stale answer")]));
+    await new Promise((settle) => setTimeout(settle, 60));
+
+    expect(screen.queryByText("Stale answer")).not.toBeInTheDocument();
+    expect(screen.getByText("Newer answer")).toBeInTheDocument();
+  });
+});
+
+describe("My Tickets — each control changes what is displayed", () => {
+  // Distinct fixtures per query, so an assertion can be about the rows on screen
+  // rather than only about the URL that asked for them.
+  function fixtures(url: URL) {
+    if (url.searchParams.get("categoryId") === "3") return page([ticket(2, "Hardware fault")]);
+    if (url.searchParams.get("relatedSystemId") === "5") return page([ticket(3, "Wi-Fi fault")]);
+    if (url.searchParams.get("requestedPriority") === "URGENT") return page([ticket(4, "Urgent fault")]);
+    if (url.searchParams.get("sortBy") === "ticketNumber") return page([ticket(5, "Sorted by number")]);
+    return page([ticket(1, "Unfiltered result")]);
+  }
+
+  it.each([
+    ["Category", "3", "Hardware fault", "categoryId", "3"],
+    ["Related System", "5", "Wi-Fi fault", "relatedSystemId", "5"],
+    ["Requested Priority", "URGENT", "Urgent fault", "requestedPriority", "URGENT"],
+    ["Sort", "ticketNumber:asc", "Sorted by number", "sortBy", "ticketNumber"],
+  ])("%s replaces the rows on screen, not just the query", async (label, choice, expected, param, value) => {
+    const { listUrls } = mockApi(fixtures);
+    await renderList();
+    expect(await screen.findByText("Unfiltered result")).toBeInTheDocument();
+
+    await userEvent.selectOptions(screen.getByLabelText(label as string), choice as string);
+
+    expect(await screen.findByText(expected as string)).toBeInTheDocument();
+    expect(screen.queryByText("Unfiltered result")).not.toBeInTheDocument();
+    expect(listUrls.at(-1)!.searchParams.get(param as string)).toBe(value);
+  });
+});
+
+describe("My Tickets — paging moves through the list", () => {
+  function twoPages(url: URL) {
+    const requested = Number(url.searchParams.get("page") ?? "1");
+    const rows = Array.from({ length: 10 }, (_, index) =>
+      ticket(requested * 100 + index, `Page ${requested} ticket ${index + 1}`),
+    );
+    return { items: rows, page: requested, pageSize: 10, totalItems: 20, totalPages: 2 };
+  }
+
+  it("requests and renders the next page, then comes back", async () => {
+    const { listUrls } = mockApi(twoPages);
+    await renderList();
+    await screen.findByRole("table");
+
+    expect(screen.getByText("Page 1 ticket 1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    const next = screen.getByRole("button", { name: "Next" });
+    expect(next).toBeEnabled();
+
+    await userEvent.click(next);
+
+    expect(await screen.findByText("Page 2 ticket 1")).toBeInTheDocument();
+    expect(screen.queryByText("Page 1 ticket 1")).not.toBeInTheDocument();
+    expect(listUrls.at(-1)!.searchParams.get("page")).toBe("2");
+
+    const nav = screen.getByRole("navigation", { name: "Ticket list pages" });
+    expect(nav).toHaveTextContent("Showing 11–20 of 20 Tickets");
+    expect(nav).toHaveTextContent("Page 2 of 2");
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Previous" }));
+
+    expect(await screen.findByText("Page 1 ticket 1")).toBeInTheDocument();
+    expect(listUrls.at(-1)!.searchParams.get("page")).toBe("1");
+  });
+});
+
+describe("My Tickets — changing requester reloads under the new identity", () => {
+  it("selects a second requester and shows their list, not the first one's", async () => {
+    // The earlier test stopped at the selector. What matters is what happens
+    // after: the list must come back under the new identity.
+    const { fetchMock } = mockApi((url) => {
+      const header = url.searchParams; // identity is not here — see the header check below
+      void header;
+      return page([ticket(1, "Belongs to whoever asked")]);
+    });
+    await renderList("1");
+    await screen.findByRole("table");
+
+    await userEvent.click(screen.getByRole("button", { name: "Change Requester" }));
+    await screen.findByRole("heading", { name: "Development Requester Selection" });
+
+    await userEvent.selectOptions(await screen.findByLabelText(/Development Requester/), "2");
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(screen.getAllByText("Somchai Pattana").length).toBeGreaterThan(0);
+
+    const listCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/tickets"));
+    const lastHeaders = (listCalls.at(-1)![1] as RequestInit).headers as Record<string, string>;
+    expect(lastHeaders["X-Dev-Requester-Id"]).toBe("2");
   });
 });
 

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -46,14 +46,17 @@ function deferred<T>() {
  * a test return a pending promise so the states between request and response are
  * reachable rather than only their endpoints.
  */
-function mockApi(listFor: (url: URL) => unknown = () => page([ticket(1, "Campus Wi-Fi drops nightly")])) {
+function mockApi(
+  listFor: (url: URL, headers: Record<string, string>) => unknown = () => page([ticket(1, "Campus Wi-Fi drops nightly")]),
+) {
   const listUrls: URL[] = [];
   const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
     const url = new URL(String(input), "http://localhost");
 
     if (url.pathname === "/api/tickets") {
       listUrls.push(url);
-      const body = await listFor(url);
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      const body = await listFor(url, headers);
       if (body instanceof Error) throw body;
       return { ok: true, status: 200, json: async () => body, headers: init?.headers };
     }
@@ -325,29 +328,69 @@ describe("My Tickets — paging moves through the list", () => {
 });
 
 describe("My Tickets — changing requester reloads under the new identity", () => {
-  it("selects a second requester and shows their list, not the first one's", async () => {
-    // The earlier test stopped at the selector. What matters is what happens
-    // after: the list must come back under the new identity.
-    const { fetchMock } = mockApi((url) => {
-      const header = url.searchParams; // identity is not here — see the header check below
-      void header;
-      return page([ticket(1, "Belongs to whoever asked")]);
-    });
+  // The fixture depends on the requester header, so "A's tickets disappear and
+  // B's appear" is actually observable. A shared fixture would prove only that
+  // the header changed, which is not what AC-08 claims.
+  function perRequester(url: URL, headers: Record<string, string>) {
+    const who = headers["X-Dev-Requester-Id"];
+    if (who === "2") return page([ticket(20, "Somchai's own ticket")]);
+    const requested = Number(url.searchParams.get("page") ?? "1");
+    return {
+      items: [ticket(requested * 10, `Nadia page ${requested} ticket`)],
+      page: requested,
+      pageSize: 10,
+      totalItems: 20,
+      totalPages: 2,
+    };
+  }
+
+  it("replaces the first requester's tickets with the second requester's", async () => {
+    const { fetchMock } = mockApi(perRequester);
     await renderList("1");
-    await screen.findByRole("table");
+
+    expect(await screen.findByText("Nadia page 1 ticket")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Change Requester" }));
     await screen.findByRole("heading", { name: "Development Requester Selection" });
-
     await userEvent.selectOptions(await screen.findByLabelText(/Development Requester/), "2");
     await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
-    expect(await screen.findByRole("table")).toBeInTheDocument();
-    expect(screen.getAllByText("Somchai Pattana").length).toBeGreaterThan(0);
+    expect(await screen.findByText("Somchai's own ticket")).toBeInTheDocument();
+    // AC-08: the previous requester's ticket must be gone, not merely re-fetched.
+    expect(screen.queryByText("Nadia page 1 ticket")).not.toBeInTheDocument();
 
     const listCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/tickets"));
     const lastHeaders = (listCalls.at(-1)![1] as RequestInit).headers as Record<string, string>;
     expect(lastHeaders["X-Dev-Requester-Id"]).toBe("2");
+  });
+
+  it("starts the new requester on page 1 with the filters cleared", async () => {
+    // BR-11: changing Requester clears requester-scoped state. Carrying a filter
+    // or a page number across would show the new requester a view shaped by
+    // somebody else's session.
+    const { listUrls } = mockApi(perRequester);
+    await renderList("1");
+    await screen.findByRole("table");
+
+    await userEvent.selectOptions(screen.getByLabelText("Category"), "3");
+    await waitFor(() => expect(listUrls.at(-1)!.searchParams.get("categoryId")).toBe("3"));
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(listUrls.at(-1)!.searchParams.get("page")).toBe("2"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Change Requester" }));
+    await screen.findByRole("heading", { name: "Development Requester Selection" });
+    await userEvent.selectOptions(await screen.findByLabelText(/Development Requester/), "2");
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(await screen.findByText("Somchai's own ticket")).toBeInTheDocument();
+
+    const afterSwitch = listUrls.at(-1)!;
+    expect(afterSwitch.searchParams.get("page")).toBe("1");
+    expect(afterSwitch.searchParams.has("categoryId")).toBe(false);
+
+    // And the controls agree with the request that was sent.
+    expect(screen.getByLabelText("Category")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Clear filters" })).toBeDisabled();
   });
 });
 

--- a/client/tests/lab-02/RequesterRouteGuard.test.tsx
+++ b/client/tests/lab-02/RequesterRouteGuard.test.tsx
@@ -14,8 +14,17 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
-function mockFetch(body: unknown = REQUESTERS) {
-  const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => body }));
+function mockFetch(bodyForRequesters: unknown = REQUESTERS) {
+  const fetchMock = vi.fn(async (input: string) => {
+    const url = new URL(String(input), "http://localhost");
+    if (url.pathname === "/api/tickets") {
+      return { ok: true, status: 200, json: async () => ({ items: [], page: 1, pageSize: 10, totalItems: 0, totalPages: 1 }) };
+    }
+    if (url.pathname === "/api/categories" || url.pathname === "/api/related-systems") {
+      return { ok: true, status: 200, json: async () => [] };
+    }
+    return { ok: true, status: 200, json: async () => bodyForRequesters };
+  });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }

--- a/client/tests/lab-02/RequesterSelector.test.tsx
+++ b/client/tests/lab-02/RequesterSelector.test.tsx
@@ -24,8 +24,20 @@ afterEach(() => {
  * defect this project has already reviewed once on a partner PR.
  */
 function mockFetch(handler: (url: string) => unknown) {
-  const fetchMock = vi.fn(async (url: string) => {
-    const body = handler(String(url));
+  const fetchMock = vi.fn(async (input: string) => {
+    const url = new URL(String(input), "http://localhost");
+
+    // Routed per endpoint. Answering every URL with the requester list is the
+    // blanket-mock pattern this project has flagged twice in review — and it
+    // would hand a requester array to the ticket list, which now really fetches.
+    if (url.pathname === "/api/tickets") {
+      return { ok: true, status: 200, json: async () => ({ items: [], page: 1, pageSize: 10, totalItems: 0, totalPages: 1 }) };
+    }
+    if (url.pathname === "/api/categories" || url.pathname === "/api/related-systems") {
+      return { ok: true, status: 200, json: async () => [] };
+    }
+
+    const body = handler(url.pathname);
     if (body instanceof Error) throw body;
     return { ok: true, status: 200, json: async () => body };
   });

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -163,7 +163,22 @@ from that run, not from a feature branch and not from memory.
 
 Run on `feature/24-my-tickets-screen` on 2026-08-30, before peer review:
 
-- `cd client && npm test` — 7 files, **75 tests passed** (up from 6 files / 61).
+- `cd client && npm test` — 7 files, **83 tests passed** (up from 6 files / 61).
+
+**Eight of those came from review.** @Earth2509 pointed out that the suite asserted *query
+construction* rather than what a user sees: it checked that selecting a Category put
+`categoryId=3` in the URL, never that the rows on screen changed. Added: a deferred response
+proving the loading state resolves to a list; per-control fixtures so Category, Related
+System, Requested Priority and Sort each visibly replace the rows; real paging through Next
+and Previous with the rendered page asserted; a completed requester change that reloads under
+the new identity; and a regression test for the stale-response guard.
+
+**The stale-response test was verified by breaking the code.** A regression test that has
+never failed is unproven, so the `active` guard was removed temporarily: the test failed with
+the stale answer on screen, and passed again once restored. That also exposed a flake of our
+own — several tests selected a filter before the reference-data request had populated the
+dropdowns, which passed in the full suite and failed when run alone. `renderList` now waits
+for the filters before returning.
 - `cd client && npm run build` — passed.
 
 **Three findings from reviewing the peer's My Tickets screen were applied here before they

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -159,6 +159,31 @@ unit, API and UI suites captured from `main` after the release merge, together w
 Playwright run and the responsive screenshots. Test counts and file paths will be filled in
 from that run, not from a feature branch and not from memory.
 
+### Issue #24 feature-branch verification
+
+Run on `feature/24-my-tickets-screen` on 2026-08-30, before peer review:
+
+- `cd client && npm test` — 7 files, **75 tests passed** (up from 6 files / 61).
+- `cd client && npm run build` — passed.
+
+**Three findings from reviewing the peer's My Tickets screen were applied here before they
+could be repeated.** Search is debounced to one request per completed term rather than one
+per keystroke; the pagination line announces the result count, not only "Page 1 of 3"; and
+Clear filters is enabled by a sort-only change, because it resets sort as well — a button
+that refuses to do what it claims is worse than no button.
+
+**A real defect, found by a test that was wrong first.** The pagination label computed the
+last row as `page x pageSize`, which is correct for a full page and a lie for any page the
+server trims. It now derives from the rows actually returned. The test that exposed it was
+itself unrealistic — one row with a total of 24 — so the fix was to correct both.
+
+**My own earlier suites used a blanket fetch mock, and it bit exactly as predicted.**
+`RequesterSelector.test.tsx` and `RequesterRouteGuard.test.tsx` answered every URL with the
+requester list. That was harmless while `/tickets` was a placeholder, and broke the moment
+the screen really fetched — the ticket list received an array of requesters. Both are now
+routed per endpoint. This is the third time this pattern has been raised in review on the
+peer's code; it is worth recording that it was in ours too.
+
 ### Issue #23 feature-branch verification
 
 Run on `feature/23-my-tickets-api` on 2026-08-30, before peer review:

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -163,7 +163,7 @@ from that run, not from a feature branch and not from memory.
 
 Run on `feature/24-my-tickets-screen` on 2026-08-30, before peer review:
 
-- `cd client && npm test` — 7 files, **83 tests passed** (up from 6 files / 61).
+- `cd client && npm test` — 7 files, **84 tests passed** (up from 6 files / 61).
 
 **Eight of those came from review.** @Earth2509 pointed out that the suite asserted *query
 construction* rather than what a user sees: it checked that selecting a Category put
@@ -172,6 +172,14 @@ proving the loading state resolves to a list; per-control fixtures so Category, 
 System, Requested Priority and Sort each visibly replace the rows; real paging through Next
 and Previous with the rendered page asserted; a completed requester change that reloads under
 the new identity; and a regression test for the stale-response guard.
+
+**A second review round found the requester-change test proving the wrong thing.** It
+returned the same fixture for both requesters, so it showed that `X-Dev-Requester-Id`
+changed and not the AC-08 behaviour that one requester's tickets disappear and the other's
+appear. The fixture now varies by the header — which meant passing the headers into the mock,
+since identity does not travel in the URL. A second test covers BR-11: a filter and a page
+are applied *before* switching, and the new requester starts on page 1 with the filters
+cleared, asserted both in the request and in the controls.
 
 **The stale-response test was verified by breaking the code.** A regression test that has
 never failed is unproven, so the `active` guard was removed temporarily: the test failed with


### PR DESCRIPTION
## Summary

The My Tickets screen: the requester's own tickets with search, filters, sort and
pagination, wired to the guarded `/tickets` route. Desktop renders a table; below 768 px each
row becomes a card, with every cell carrying its own label so a value is never orphaned from
its column.

## Three things I took from reviewing your My Tickets screen

Applying them here before repeating them seemed better than discovering them twice.

- **Search is debounced** to one request per completed term. Typing `laptop` otherwise costs
  six round trips, and with the table torn down on each one it flickers under the user's
  hands.
- **The pagination line announces the result count** — "Showing 1–10 of 24 Tickets · Page 1
  of 3" — not just the page number.
- **Clear filters is enabled by a sort-only change**, because it resets sort as well. A
  button that refuses to do something it claims to do is worse than no button.

I also kept the `active`-flag guard from your implementation. It is what stops a slow
response from an abandoned query overwriting a newer one, and it matters more here than it
looks, because a debounce shortens that window without closing it.

## A real defect, found by a test that was itself wrong

The pagination label computed the last row as `page × pageSize`. That is right for a full
page and a lie for any page the server trims — the last page of 24 would have claimed to be
showing rows the server never sent. It now derives from the rows actually returned.

The test that exposed it was unrealistic in its own way: one row with a total of 24, which
cannot happen at a page size of 10. So both were wrong, and both are fixed. Worth saying
plainly, because "the test failed so I changed the test" is exactly the move I would
challenge in review.

## And my own blanket mock bit me

`RequesterSelector.test.tsx` and `RequesterRouteGuard.test.tsx` answered *every* URL with the
requester list. That was harmless while `/tickets` was a placeholder, and broke the moment
the screen really fetched — the ticket list was handed an array of requesters and the render
collapsed. Both are now routed per endpoint.

This is the third time this pattern has come up in review on your code, so it is only fair to
record that it was in mine as well. It survived because nothing exercised it, which is the
whole problem with a mock that answers everything.

## Validation

- `cd client && npm test` — 7 files, **75 tests passed** (up from 6 / 61).
- `cd client && npm run build` — passed.

There is no Current Status filter: every Lab 2 Ticket is `NEW` (BR-30), and the API rejects
the parameter rather than ignoring it, so offering the control would be offering a lie.

## Review focus

1. Ticket Number and Summary both link to `/tickets/:id`, which is a placeholder until #26.
   Reasonable, or would you rather the links waited for the screen?
2. The mobile card layout uses `data-label` on each cell rather than a separate card
   component. Accessible enough, or worth building the card properly?
3. `Refresh` sits beside `Clear filters`. Useful, or clutter given the list reloads on every
   filter change anyway?

Relates to #24
