### PR TITLE
Issue 26: Ticket Detail screen and attachment UI

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,10 @@
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
-import { AppShell, Card, type NavItem } from "./components/index.js";
+import { AppShell, type NavItem } from "./components/index.js";
 import SystemCheck from "./SystemCheck.js";
 import { RequesterProvider, RequesterSelector, RequireRequester, useRequester } from "./requester/index.js";
 import CreateTicket from "./tickets/CreateTicket.js";
 import MyTickets from "./tickets/MyTickets.js";
+import TicketDetail from "./tickets/TicketDetail.js";
 
 // Routes, so that AC-02 — opening a requester-scoped route directly shows the
 // selector — is a real claim about a real URL rather than about which branch of
@@ -68,7 +69,7 @@ function Shell() {
           path="/tickets/:ticketId"
           element={
             <RequireRequester>
-              <ComingSoon title="Ticket Detail" issue={26} />
+              <TicketDetail />
             </RequireRequester>
           }
         />
@@ -76,23 +77,5 @@ function Shell() {
         <Route path="*" element={<Navigate to="/tickets" replace />} />
       </Routes>
     </AppShell>
-  );
-}
-
-/**
- * A screen that exists as a route but not yet as a feature. Shown rather than
- * hidden so the shell, the navigation and the guard are all real and reviewable
- * now, and says which issue delivers it rather than implying it is broken.
- */
-function ComingSoon({ title, issue }: { title: string; issue: number }) {
-  const { requester } = useRequester();
-
-  return (
-    <Card title={title} as="h1">
-      <p>
-        This screen is delivered by Issue #{issue}. The Development Requester context is
-        already in place: you are working as <strong>{requester?.fullName}</strong>.
-      </p>
-    </Card>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -117,32 +117,40 @@ type ErrorEnvelope = {
   error?: { code?: string; message?: string; fieldErrors?: Record<string, string> };
 };
 
-async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
-  let response: Response;
+/**
+ * Turns a failed response into the error envelope the UI can display. Shared by
+ * the JSON calls and the attachment download, which fails with the same envelope
+ * even though it succeeds with bytes.
+ */
+async function toApiError(response: Response): Promise<ApiError> {
+  // Named rather than inferred: `typeof envelope` narrows to `null` after the
+  // initialiser, so casting to it would collapse the parsed body to `never`.
+  let envelope: ErrorEnvelope | null = null;
   try {
-    response = await fetch(`${API_URL}${path}`, init);
+    envelope = (await response.json()) as ErrorEnvelope;
+  } catch {
+    // A non-JSON error body is itself a failure worth reporting safely.
+  }
+  return new ApiError(
+    envelope?.error?.message ?? "The request could not be completed.",
+    envelope?.error?.code,
+    envelope?.error?.fieldErrors,
+    response.status,
+  );
+}
+
+async function send(path: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(`${API_URL}${path}`, init);
   } catch {
     // The browser's raw TypeError never reaches a component (BR-43).
     throw new ApiError(UNREACHABLE_MESSAGE);
   }
+}
 
-  if (!response.ok) {
-    // Named rather than inferred: `typeof envelope` narrows to `null` after the
-    // initialiser, so casting to it would collapse the parsed body to `never`.
-    let envelope: ErrorEnvelope | null = null;
-    try {
-      envelope = (await response.json()) as ErrorEnvelope;
-    } catch {
-      // A non-JSON error body is itself a failure worth reporting safely.
-    }
-    throw new ApiError(
-      envelope?.error?.message ?? "The request could not be completed.",
-      envelope?.error?.code,
-      envelope?.error?.fieldErrors,
-      response.status,
-    );
-  }
-
+async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await send(path, init);
+  if (!response.ok) throw await toApiError(response);
   return (await response.json()) as T;
 }
 
@@ -229,4 +237,100 @@ export async function fetchTickets(
   return requestJson<TicketListResponse>(`/api/tickets${suffix ? `?${suffix}` : ""}`, {
     headers: { "X-Dev-Requester-Id": String(requesterId) },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Issue 26 — Ticket Detail and attachments
+// ---------------------------------------------------------------------------
+
+/**
+ * Attachment metadata as the API returns it (api-spec.md §4). A removed
+ * attachment keeps every field it had and gains the three removal ones, because
+ * BR-37 makes removal a record rather than a deletion.
+ */
+export interface Attachment {
+  id: number;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  uploadedAt: string;
+  removedAt: string | null;
+  removedByRequesterId: number | null;
+  removalReason: string | null;
+}
+
+/** The detail response: the create shape, with the attachments filled in. */
+export interface TicketDetail extends CreatedTicket {
+  attachments: Attachment[];
+}
+
+export async function fetchTicket(ticketId: number, requesterId: number): Promise<TicketDetail> {
+  return requestJson<TicketDetail>(`/api/tickets/${ticketId}`, {
+    headers: { "X-Dev-Requester-Id": String(requesterId) },
+  });
+}
+
+export async function fetchAttachments(ticketId: number, requesterId: number): Promise<Attachment[]> {
+  return requestJson<Attachment[]>(`/api/tickets/${ticketId}/attachments`, {
+    headers: { "X-Dev-Requester-Id": String(requesterId) },
+  });
+}
+
+/**
+ * One file per request, under the field name the API expects.
+ *
+ * `Content-Type` is deliberately not set: the browser has to write it itself so
+ * that it carries the multipart boundary. Setting it by hand produces a body the
+ * server cannot parse, which then looks like a validation bug rather than a
+ * transport one.
+ */
+export async function uploadAttachment(
+  ticketId: number,
+  file: File,
+  requesterId: number,
+): Promise<Attachment> {
+  const body = new FormData();
+  body.append("file", file);
+
+  return requestJson<Attachment>(`/api/tickets/${ticketId}/attachments`, {
+    method: "POST",
+    headers: { "X-Dev-Requester-Id": String(requesterId) },
+    body,
+  });
+}
+
+export async function removeAttachment(
+  ticketId: number,
+  attachmentId: number,
+  removalReason: string,
+  requesterId: number,
+): Promise<Attachment> {
+  return requestJson<Attachment>(`/api/tickets/${ticketId}/attachments/${attachmentId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Dev-Requester-Id": String(requesterId),
+    },
+    body: JSON.stringify({ removalReason }),
+  });
+}
+
+/**
+ * Downloads through fetch rather than a plain link.
+ *
+ * The endpoint is requester-scoped and identity travels in `X-Dev-Requester-Id`
+ * (D-01), and a browser navigation cannot carry a custom header — an `<a href>`
+ * would arrive without context and be answered `401`. So the bytes are fetched
+ * with the header and handed to the caller to save.
+ */
+export async function downloadAttachment(
+  ticketId: number,
+  attachmentId: number,
+  requesterId: number,
+): Promise<Blob> {
+  const response = await send(`/api/tickets/${ticketId}/attachments/${attachmentId}/download`, {
+    headers: { "X-Dev-Requester-Id": String(requesterId) },
+  });
+  if (!response.ok) throw await toApiError(response);
+  return response.blob();
 }

--- a/client/src/styles/zen-green.css
+++ b/client/src/styles/zen-green.css
@@ -555,3 +555,71 @@ body {
     text-align: center;
   }
 }
+
+/* ------------------------------------------------------------ attachments
+   One card per file rather than a table row: a filename, a state badge, a
+   removal reason and two actions do not survive being squeezed into columns at
+   390px, and ui-spec.md 9 forbids the page scrolling sideways to save them. */
+
+.zen-attachments {
+  margin: var(--zen-space-4) 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--zen-space-3);
+}
+
+.zen-attachment {
+  padding: var(--zen-space-4);
+  border: 1px solid var(--zen-border);
+  border-left: 4px solid var(--zen-primary);
+  border-radius: var(--zen-radius);
+  background: var(--zen-surface);
+}
+
+/* Removed files are dimmer and marked, but the text stays at full contrast:
+   the state is carried by the badge and the sentence, not by the colour. */
+.zen-attachment--removed {
+  border-left-color: var(--zen-text-muted);
+  background: var(--zen-readonly);
+}
+
+.zen-attachment__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--zen-space-3);
+}
+
+.zen-attachment__name {
+  font-weight: 700;
+  /* Long filenames wrap instead of overflowing their card. */
+  overflow-wrap: anywhere;
+}
+
+.zen-attachment__meta {
+  margin: var(--zen-space-2) 0 0;
+  color: var(--zen-text-muted);
+  font-size: 0.9rem;
+}
+
+.zen-attachment__removal {
+  margin: var(--zen-space-2) 0 0;
+  color: var(--zen-text);
+}
+
+.zen-attachment__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--zen-space-3);
+  margin-top: var(--zen-space-3);
+}
+
+@media (max-width: 767px) {
+  /* .zen-button is full width on mobile, so the actions stack rather than
+     leaving two half-buttons fighting for one row. */
+  .zen-attachment__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/client/src/tickets/CreateTicket.tsx
+++ b/client/src/tickets/CreateTicket.tsx
@@ -241,13 +241,16 @@ export default function CreateTicket() {
         {files.length > 0 && (
           <p>
             {files.length} selected {files.length === 1 ? "file was" : "files were"} checked but{" "}
-            <strong>not uploaded</strong> — attachments are added from the Ticket Detail screen,
-            which arrives with Issue #26. Nothing has been stored, so they will need choosing again.
+            <strong>not uploaded</strong> — attachments are added from this Ticket's detail screen
+            (BR-34). Nothing has been stored, so they will need choosing again there.
           </p>
         )}
 
         <div className="zen-shell__nav">
-          <Link className="zen-button zen-button--primary" to="/tickets">
+          <Link className="zen-button zen-button--primary" to={`/tickets/${created.id}`}>
+            Open this Ticket
+          </Link>
+          <Link className="zen-button zen-button--secondary" to="/tickets">
             View My Tickets
           </Link>
           <Button variant="secondary" onClick={createAnother}>

--- a/client/src/tickets/TicketDetail.tsx
+++ b/client/src/tickets/TicketDetail.tsx
@@ -1,0 +1,377 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  ApiError,
+  downloadAttachment,
+  fetchTicket,
+  removeAttachment,
+  uploadAttachment,
+  type Attachment,
+  type RequestedPriority,
+  type TicketDetail as TicketDetailResponse,
+} from "../api.js";
+import {
+  Badge,
+  Button,
+  Card,
+  ErrorAlert,
+  Field,
+  ReadOnlyField,
+  StatusMessage,
+} from "../components/index.js";
+import { useRequester } from "../requester/index.js";
+import {
+  MAX_FILES,
+  PERMITTED_TYPE_LABEL,
+  describeRejections,
+  selectAttachments,
+} from "./attachment-selection.js";
+import { saveBlob } from "./save-file.js";
+
+// BR-38, mirrored from the server so the confirm button can say no before a
+// round trip. The server re-checks and remains the authority.
+const REASON_MIN = 5;
+const REASON_MAX = 250;
+
+const PRIORITY_TONE: Record<RequestedPriority, "neutral" | "warning" | "danger"> = {
+  LOW: "neutral",
+  MEDIUM: "neutral",
+  HIGH: "warning",
+  URGENT: "danger",
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  "image/jpeg": "JPEG image",
+  "image/png": "PNG image",
+  "image/webp": "WEBP image",
+  "application/pdf": "PDF document",
+};
+
+function describeType(mimeType: string): string {
+  return TYPE_LABELS[mimeType] ?? mimeType;
+}
+
+function describeSize(bytes: number): string {
+  // Kilobytes below a megabyte: "0.2 MB" for a screenshot tells the reader less
+  // than "184 KB" does, and the column exists to be read rather than to be neat.
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function moment(value: string): string {
+  return new Date(value).toLocaleString();
+}
+
+export default function TicketDetail() {
+  const { ticketId = "" } = useParams();
+  const { requester } = useRequester();
+
+  const [ticket, setTicket] = useState<TicketDetailResponse | null>(null);
+  const [state, setState] = useState<"loading" | "ready" | "notFound" | "failed">("loading");
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [attachmentError, setAttachmentError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [uploadingName, setUploadingName] = useState("");
+
+  const [removingId, setRemovingId] = useState<number | null>(null);
+  const [reason, setReason] = useState("");
+  const [reasonError, setReasonError] = useState("");
+  const [removalBusy, setRemovalBusy] = useState(false);
+
+  useEffect(() => {
+    if (!requester) return;
+    let active = true;
+    setState("loading");
+
+    fetchTicket(Number(ticketId), requester.id)
+      .then((loaded) => {
+        if (!active) return;
+        setTicket(loaded);
+        setAttachments(loaded.attachments);
+        setState("ready");
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        // A Ticket that is not yours and a Ticket that does not exist are the
+        // same answer by design (BR-10, D-04), and the screen must not undo that
+        // by wording them differently.
+        setState(error instanceof ApiError && error.status === 404 ? "notFound" : "failed");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [requester, ticketId, reloadToken]);
+
+  const activeCount = attachments.filter((file) => file.removedAt === null).length;
+  const atLimit = activeCount >= MAX_FILES;
+
+  async function upload(chosen: File | undefined, input: HTMLInputElement) {
+    // The picker keeps its value, so choosing the same file twice after a failure
+    // would otherwise be silent. Clearing it makes every choice a fresh event.
+    input.value = "";
+    if (!chosen || !requester || !ticket) return;
+
+    setNotice("");
+
+    const { rejected } = selectAttachments([chosen]);
+    if (rejected.length > 0) {
+      // Named with its reason, and never added to the list (ui-spec.md §8).
+      setAttachmentError(describeRejections(rejected));
+      return;
+    }
+
+    setAttachmentError("");
+    setUploadingName(chosen.name);
+    try {
+      const stored = await uploadAttachment(ticket.id, chosen, requester.id);
+      setAttachments((current) => [...current, stored]);
+      setNotice(`${stored.originalFilename} was uploaded.`);
+    } catch (error) {
+      const message = error instanceof ApiError ? error.message : "The attachment could not be uploaded.";
+      setAttachmentError(`${chosen.name} was not uploaded — ${message}`);
+    } finally {
+      setUploadingName("");
+    }
+  }
+
+  async function download(attachment: Attachment) {
+    if (!requester || !ticket) return;
+    setAttachmentError("");
+    setNotice("");
+    try {
+      const blob = await downloadAttachment(ticket.id, attachment.id, requester.id);
+      saveBlob(blob, attachment.originalFilename);
+      setNotice(`${attachment.originalFilename} was downloaded.`);
+    } catch (error) {
+      const message = error instanceof ApiError ? error.message : "The attachment could not be downloaded.";
+      setAttachmentError(`${attachment.originalFilename} could not be downloaded — ${message}`);
+    }
+  }
+
+  function startRemoval(attachment: Attachment) {
+    setRemovingId(attachment.id);
+    setReason("");
+    setReasonError("");
+    setAttachmentError("");
+    setNotice("");
+  }
+
+  async function confirmRemoval(attachment: Attachment) {
+    if (!requester || !ticket) return;
+
+    const trimmed = reason.trim();
+    if (trimmed.length < REASON_MIN || trimmed.length > REASON_MAX) {
+      setReasonError(`Give a removal reason of ${REASON_MIN}-${REASON_MAX} characters.`);
+      return;
+    }
+
+    setRemovalBusy(true);
+    try {
+      const removed = await removeAttachment(ticket.id, attachment.id, trimmed, requester.id);
+      // Replaced rather than dropped: the row stays on screen carrying its
+      // removal reason and date, which is the whole point of a soft removal.
+      setAttachments((current) => current.map((file) => (file.id === removed.id ? removed : file)));
+      setRemovingId(null);
+      setReason("");
+      setNotice(`${removed.originalFilename} was removed and can no longer be downloaded.`);
+    } catch (error) {
+      const apiError = error instanceof ApiError ? error : null;
+      if (apiError?.fieldErrors?.removalReason) {
+        setReasonError(apiError.fieldErrors.removalReason);
+      } else {
+        setAttachmentError(
+          `${attachment.originalFilename} could not be removed — ${apiError?.message ?? "please try again."}`,
+        );
+      }
+    } finally {
+      setRemovalBusy(false);
+    }
+  }
+
+  if (state === "loading") {
+    return (
+      <Card title="Ticket" as="h1">
+        <StatusMessage>Loading this Ticket…</StatusMessage>
+      </Card>
+    );
+  }
+
+  if (state === "notFound") {
+    return (
+      <Card title="Ticket not found" as="h1">
+        <ErrorAlert>
+          That Ticket could not be found. It may not exist, or it may belong to a different
+          Development Requester.
+        </ErrorAlert>
+        <Link className="zen-button zen-button--secondary" to="/tickets">
+          Back to My Tickets
+        </Link>
+      </Card>
+    );
+  }
+
+  if (state === "failed" || !ticket) {
+    return (
+      <Card title="Ticket" as="h1">
+        <ErrorAlert onRetry={() => setReloadToken((token) => token + 1)}>
+          This Ticket could not be loaded.
+        </ErrorAlert>
+        <Link className="zen-button zen-button--secondary" to="/tickets">
+          Back to My Tickets
+        </Link>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card title={`Ticket ${ticket.ticketNumber}`} as="h1">
+        {/* Every field is read-only. Lab 2 has no edit, so nothing here should
+            look like it invites one (ui-spec.md §8). */}
+        <ReadOnlyField label="Ticket Number" value={ticket.ticketNumber} />
+        <ReadOnlyField label="Ticket Date" value={moment(ticket.ticketDate)} />
+        <ReadOnlyField label="Requester" value={ticket.requester.fullName} />
+        <ReadOnlyField label="Category" value={ticket.category.name} />
+        <ReadOnlyField label="Related System" value={ticket.relatedSystem.name} />
+        <ReadOnlyField label="Ticket Summary" value={ticket.summary} />
+        <ReadOnlyField
+          label="Requested Priority"
+          value={<Badge tone={PRIORITY_TONE[ticket.requestedPriority]}>{ticket.requestedPriority}</Badge>}
+        />
+        <ReadOnlyField label="Current Status" value={<Badge tone="success">{ticket.currentStatus}</Badge>} />
+        <ReadOnlyField label="Description" value={ticket.description} />
+
+        <Link className="zen-button zen-button--secondary" to="/tickets">
+          Back to My Tickets
+        </Link>
+      </Card>
+
+      <Card title="Attachments">
+        <p className="zen-field__hint">
+          {PERMITTED_TYPE_LABEL}, up to 5 MB each, {MAX_FILES} active attachments maximum.{" "}
+          {activeCount} of {MAX_FILES} in use.
+        </p>
+
+        {/* Upload errors sit beside the attachment section and name the file
+            they concern, rather than as a banner at the top of the page. */}
+        {attachmentError && <ErrorAlert>{attachmentError}</ErrorAlert>}
+        {uploadingName && <StatusMessage>Uploading {uploadingName}…</StatusMessage>}
+        {notice && <StatusMessage>{notice}</StatusMessage>}
+
+        <Field
+          id="attachment"
+          label="Add an attachment"
+          hint={
+            atLimit
+              ? `This Ticket already has ${MAX_FILES} active attachments. Remove one before adding another.`
+              : undefined
+          }
+        >
+          {(control) => (
+            <input
+              {...control}
+              type="file"
+              accept="image/jpeg,image/png,image/webp,application/pdf"
+              disabled={atLimit || uploadingName !== ""}
+              onChange={(event) => void upload(event.target.files?.[0], event.target)}
+            />
+          )}
+        </Field>
+
+        {attachments.length === 0 ? (
+          <p>No files have been attached to this Ticket.</p>
+        ) : (
+          <ul className="zen-attachments" aria-label="Attachments">
+            {attachments.map((attachment) => {
+              const removed = attachment.removedAt !== null;
+              return (
+                <li key={attachment.id} className={`zen-attachment${removed ? " zen-attachment--removed" : ""}`}>
+                  <div className="zen-attachment__head">
+                    <span className="zen-attachment__name">{attachment.originalFilename}</span>
+                    {removed ? <Badge tone="danger">Removed</Badge> : <Badge tone="success">Active</Badge>}
+                  </div>
+
+                  <p className="zen-attachment__meta">
+                    {describeType(attachment.mimeType)} · {describeSize(attachment.sizeBytes)} · uploaded{" "}
+                    {moment(attachment.uploadedAt)}
+                  </p>
+
+                  {removed && attachment.removedAt && (
+                    // The metadata is retained and the reason is spelled out in
+                    // words, so the state is never carried by the badge colour
+                    // alone (BR-39, ui-spec.md §10).
+                    <p className="zen-attachment__removal">
+                      Removed on {moment(attachment.removedAt)} — reason: {attachment.removalReason}. Download is
+                      unavailable because this attachment was removed.
+                    </p>
+                  )}
+
+                  {!removed && (
+                    <div className="zen-attachment__actions">
+                      <Button variant="secondary" onClick={() => void download(attachment)}>
+                        Download {attachment.originalFilename}
+                      </Button>
+                      <Button variant="destructive" onClick={() => startRemoval(attachment)}>
+                        Remove {attachment.originalFilename}
+                      </Button>
+                    </div>
+                  )}
+
+                  {removingId === attachment.id && (
+                    <div className="zen-alert" role="alertdialog" aria-label={`Remove ${attachment.originalFilename}?`}>
+                      <p>
+                        Remove <strong>{attachment.originalFilename}</strong>? The file stops being
+                        downloadable, and this record of why it went keeps its place on the Ticket.
+                      </p>
+
+                      <Field
+                        id={`removal-reason-${attachment.id}`}
+                        label="Removal reason"
+                        required
+                        error={reasonError}
+                        hint={`${REASON_MIN}-${REASON_MAX} characters. ${reason.trim().length} so far.`}
+                      >
+                        {(control) => (
+                          <input
+                            {...control}
+                            type="text"
+                            value={reason}
+                            onChange={(event) => {
+                              setReason(event.target.value);
+                              setReasonError("");
+                            }}
+                          />
+                        )}
+                      </Field>
+
+                      <div className="zen-attachment__actions">
+                        <Button
+                          variant="destructive"
+                          busy={removalBusy}
+                          busyLabel="Removing…"
+                          // Disabled until the reason is one the server would
+                          // accept: offering a button that is certain to fail is
+                          // just a slower way of showing an error.
+                          disabled={reason.trim().length < REASON_MIN || reason.trim().length > REASON_MAX}
+                          onClick={() => void confirmRemoval(attachment)}
+                        >
+                          Remove attachment
+                        </Button>
+                        <Button variant="secondary" disabled={removalBusy} onClick={() => setRemovingId(null)}>
+                          Keep attachment
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Card>
+    </>
+  );
+}

--- a/client/src/tickets/save-file.ts
+++ b/client/src/tickets/save-file.ts
@@ -1,0 +1,19 @@
+/**
+ * Hands a downloaded blob to the browser as a saved file.
+ *
+ * The attachment endpoint needs the `X-Dev-Requester-Id` header, which a plain
+ * link cannot carry, so the bytes arrive through fetch and this is what turns
+ * them back into a download. The object URL is revoked immediately afterwards:
+ * it holds the whole file in memory until it is, and a detail screen visited
+ * repeatedly would otherwise accumulate them.
+ */
+export function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -1,0 +1,407 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import App from "../../src/App.js";
+import { REQUESTER_STORAGE_KEY } from "../../src/requester/index.js";
+
+// UI-10, UI-11 — AC-12, AC-14, AC-15.
+
+const REQUESTERS = [
+  { id: 1, fullName: "Nadia Rahman", email: "nadia.rahman@toktickit.local" },
+  { id: 2, fullName: "Somchai Pattana", email: "somchai.pattana@toktickit.local" },
+];
+
+const ACTIVE_FILE = {
+  id: 7,
+  originalFilename: "wifi-error.png",
+  mimeType: "image/png",
+  sizeBytes: 184203,
+  uploadedAt: "2026-08-30T09:20:41.004Z",
+  removedAt: null,
+  removedByRequesterId: null,
+  removalReason: null,
+};
+
+const REMOVED_FILE = {
+  id: 8,
+  originalFilename: "wrong-screenshot.pdf",
+  mimeType: "application/pdf",
+  sizeBytes: 2 * 1024 * 1024,
+  uploadedAt: "2026-08-30T09:25:00.000Z",
+  removedAt: "2026-08-30T10:02:00.000Z",
+  removedByRequesterId: 1,
+  removalReason: "Uploaded the wrong screenshot",
+};
+
+function detail(attachments: unknown[] = []) {
+  return {
+    id: 42,
+    ticketNumber: "TKT-2026-00042",
+    ticketDate: "2026-08-30T09:14:22.518Z",
+    requester: { id: 1, fullName: "Nadia Rahman" },
+    category: { id: 2, name: "Network" },
+    relatedSystem: { id: 5, name: "Campus Wi-Fi" },
+    summary: "Cannot connect to Campus Wi-Fi in Building 4",
+    description: "My laptop reports an authentication failure on the campus network.",
+    requestedPriority: "HIGH",
+    currentStatus: "NEW",
+    attachments,
+    createdAt: "2026-08-30T09:14:22.518Z",
+    updatedAt: "2026-08-30T09:14:22.518Z",
+  };
+}
+
+/** The server's error envelope, as api-spec.md 5 defines it. */
+function envelope(status: number, code: string, message: string, fieldErrors?: Record<string, string>) {
+  return { status, body: { error: { code, message, ...(fieldErrors ? { fieldErrors } : {}) } } };
+}
+
+type Handler = (init: RequestInit | undefined) => { status: number; body: unknown } | Blob;
+
+/**
+ * Routes by method and path so a test can answer one call differently without
+ * restating the others. Every request is recorded, which is what lets the
+ * ownership test assert on the header actually sent rather than on the props of
+ * a component.
+ */
+function mockApi(handlers: Record<string, Handler> = {}) {
+  const calls: { method: string; path: string; headers: Record<string, string>; body: unknown }[] = [];
+
+  const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+    const url = new URL(String(input), "http://localhost");
+    const method = (init?.method ?? "GET").toUpperCase();
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    calls.push({ method, path: url.pathname, headers, body: init?.body });
+
+    const handler = handlers[`${method} ${url.pathname}`];
+    if (handler) {
+      const answer = handler(init);
+      if (answer instanceof Blob) {
+        return { ok: true, status: 200, blob: async () => answer };
+      }
+      return {
+        ok: answer.status < 400,
+        status: answer.status,
+        json: async () => answer.body,
+        blob: async () => new Blob([]),
+      };
+    }
+
+    if (url.pathname === "/api/requesters") return { ok: true, status: 200, json: async () => REQUESTERS };
+    if (url.pathname === "/api/tickets/42") return { ok: true, status: 200, json: async () => detail() };
+    throw new Error(`Unexpected request: ${method} ${url.pathname}`);
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, calls };
+}
+
+async function renderDetail(ticketId = "42", requesterId = "1") {
+  window.localStorage.setItem(REQUESTER_STORAGE_KEY, requesterId);
+  render(
+    <MemoryRouter initialEntries={[`/tickets/${ticketId}`]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+function png(name: string, bytes = 1024): File {
+  return new File([new Uint8Array(bytes)], name, { type: "image/png" });
+}
+
+/** The card a heading belongs to, so an assertion cannot match the app shell —
+ *  which also displays the requester's name. */
+function cardFor(heading: RegExp | string): HTMLElement {
+  return screen.getByRole("heading", { name: heading }).closest("section") as HTMLElement;
+}
+
+// jsdom implements neither half of the object-URL API, and the download path
+// needs both. Redefined per test so the calls can be counted.
+const objectUrl = { create: vi.fn(() => "blob:stub"), revoke: vi.fn() };
+
+beforeEach(() => {
+  objectUrl.create.mockClear();
+  objectUrl.revoke.mockClear();
+  Object.assign(URL, { createObjectURL: objectUrl.create, revokeObjectURL: objectUrl.revoke });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("Ticket Detail — the read-only record", () => {
+  it("shows every ticket field as a read-only value, not as an editable control", async () => {
+    mockApi({ "GET /api/tickets/42": () => ({ status: 200, body: detail() }) });
+    await renderDetail();
+
+    await screen.findByRole("heading", { name: "Ticket TKT-2026-00042" });
+    // Scoped to the ticket card: the shell shows the requester's name too, and
+    // an assertion that cannot tell them apart proves nothing about the screen.
+    const card = within(cardFor(/^Ticket TKT-/));
+
+    for (const [label, value] of [
+      ["Ticket Number", "TKT-2026-00042"],
+      ["Requester", "Nadia Rahman"],
+      ["Category", "Network"],
+      ["Related System", "Campus Wi-Fi"],
+      ["Ticket Summary", "Cannot connect to Campus Wi-Fi in Building 4"],
+      ["Requested Priority", "HIGH"],
+      ["Current Status", "NEW"],
+      ["Description", "My laptop reports an authentication failure on the campus network."],
+    ] as const) {
+      expect(card.getByText(label)).toBeInTheDocument();
+      expect(card.getByText(value)).toBeInTheDocument();
+    }
+
+    // The distinction the labsheet grades is read-only versus editable, so the
+    // claim is about what the DOM contains: no textbox, combobox or textarea
+    // carries any of these values.
+    expect(screen.queryByRole("textbox", { name: /Summary|Description/ })).toBeNull();
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(document.querySelectorAll(".zen-field--readonly").length).toBeGreaterThanOrEqual(9);
+  });
+
+  it("asks for the ticket as the selected requester and shows nothing before the answer", async () => {
+    const { calls } = mockApi({ "GET /api/tickets/42": () => ({ status: 200, body: detail() }) });
+    await renderDetail("42", "2");
+
+    await screen.findByRole("heading", { name: "Ticket TKT-2026-00042" });
+    const detailCall = calls.find((call) => call.path === "/api/tickets/42");
+    expect(detailCall?.headers["X-Dev-Requester-Id"]).toBe("2");
+  });
+});
+
+describe("Ticket Detail — a ticket that is not yours", () => {
+  it("reports a 404 without disclosing that the ticket exists", async () => {
+    mockApi({
+      "GET /api/tickets/42": () => envelope(404, "TICKET_NOT_FOUND", "That Ticket could not be found."),
+    });
+    await renderDetail();
+
+    await screen.findByRole("heading", { name: "Ticket not found" });
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/could not be found/i);
+
+    // No field of the ticket reaches the screen, and nothing on it says who does
+    // own the ticket — the two failures stay indistinguishable (D-04).
+    expect(screen.queryByText("TKT-2026-00042")).toBeNull();
+    expect(screen.queryByText("Somchai Pattana")).toBeNull();
+    expect(screen.queryByRole("list", { name: "Attachments" })).toBeNull();
+  });
+
+  it("offers a retry when the backend fails, and recovers on it", async () => {
+    let attempt = 0;
+    mockApi({
+      "GET /api/tickets/42": () => {
+        attempt += 1;
+        return attempt === 1
+          ? envelope(503, "DEPENDENCY_UNAVAILABLE", "The service is temporarily unavailable.")
+          : { status: 200, body: detail() };
+      },
+    });
+    await renderDetail();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/could not be loaded/i);
+    // A failure and a refusal read differently: this one is worth retrying and
+    // says so, while "not found" offers no retry at all.
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await screen.findByRole("heading", { name: "Ticket TKT-2026-00042" });
+  });
+});
+
+describe("Ticket Detail — attachment states", () => {
+  it("keeps a removed attachment as marked metadata with no download control", async () => {
+    mockApi({ "GET /api/tickets/42": () => ({ status: 200, body: detail([ACTIVE_FILE, REMOVED_FILE]) }) });
+    await renderDetail();
+
+    const list = await screen.findByRole("list", { name: "Attachments" });
+    const [active, removed] = within(list).getAllByRole("listitem");
+
+    expect(within(active).getByText("wifi-error.png")).toBeInTheDocument();
+    expect(within(active).getByText("Active")).toBeInTheDocument();
+    expect(within(active).getByRole("button", { name: /^Download wifi-error\.png$/ })).toBeInTheDocument();
+
+    // The metadata survives removal: filename, type, size and upload time are
+    // all still there, alongside the reason and the removal date (BR-37, BR-39).
+    expect(within(removed).getByText("wrong-screenshot.pdf")).toBeInTheDocument();
+    expect(within(removed).getByText(/PDF document/)).toHaveTextContent(/2\.0 MB/);
+    expect(within(removed).getByText("Removed")).toBeInTheDocument();
+    expect(within(removed).getByText(/Uploaded the wrong screenshot/)).toBeInTheDocument();
+
+    // No download control at all for it, and the absence is explained in words
+    // rather than left for the reader to infer from a colour.
+    expect(within(removed).queryByRole("button", { name: /Download/ })).toBeNull();
+    expect(within(removed).getByText(/Download is unavailable because this attachment was removed/)).toBeInTheDocument();
+    expect(within(removed).queryByRole("button", { name: /Remove/ })).toBeNull();
+  });
+
+  it("downloads an active attachment with the requester header, since a link cannot carry one", async () => {
+    const { calls } = mockApi({
+      "GET /api/tickets/42": () => ({ status: 200, body: detail([ACTIVE_FILE]) }),
+      "GET /api/tickets/42/attachments/7/download": () => new Blob([new Uint8Array([1, 2, 3])]),
+    });
+    await renderDetail();
+
+    const list = await screen.findByRole("list", { name: "Attachments" });
+    await userEvent.click(within(list).getByRole("button", { name: /^Download wifi-error\.png$/ }));
+
+    await waitFor(() => expect(objectUrl.create).toHaveBeenCalled());
+    const download = calls.find((call) => call.path.endsWith("/download"));
+    expect(download?.headers["X-Dev-Requester-Id"]).toBe("1");
+    // The object URL is released once the save is triggered; a detail screen
+    // visited repeatedly would otherwise hold every file it downloaded.
+    expect(objectUrl.revoke).toHaveBeenCalledWith("blob:stub");
+  });
+});
+
+describe("Ticket Detail — uploading", () => {
+  it("names a rejected file with its reason and sends nothing", async () => {
+    const { calls } = mockApi({ "GET /api/tickets/42": () => ({ status: 200, body: detail() }) });
+    await renderDetail();
+    await screen.findByRole("heading", { name: "Attachments" });
+
+    // fireEvent, not userEvent.upload: userEvent honours the `accept` attribute
+    // and would drop payload.exe before the component ever saw it. A browser
+    // treats accept as a hint — drag-and-drop ignores it — which is why the
+    // check cannot live in the attribute.
+    fireEvent.change(screen.getByLabelText("Add an attachment"), {
+      target: { files: [new File([new Uint8Array(1024)], "payload.exe", { type: "application/x-msdownload" })] },
+    });
+
+    // The rejection is client-side, so the server is never asked. The file is
+    // named alongside the reason rather than reported as "invalid file".
+    expect(screen.getByRole("alert")).toHaveTextContent(/payload\.exe is not a permitted type/);
+    expect(calls.some((call) => call.method === "POST")).toBe(false);
+    expect(screen.queryByRole("list", { name: "Attachments" })).toBeNull();
+  });
+
+  it("adds an uploaded file to the list and announces it", async () => {
+    mockApi({
+      "GET /api/tickets/42": () => ({ status: 200, body: detail() }),
+      "POST /api/tickets/42/attachments": () => ({ status: 201, body: ACTIVE_FILE }),
+    });
+    await renderDetail();
+    await screen.findByRole("heading", { name: "Attachments" });
+
+    await userEvent.upload(screen.getByLabelText("Add an attachment"), png("wifi-error.png"));
+
+    const list = await screen.findByRole("list", { name: "Attachments" });
+    expect(within(list).getByText("wifi-error.png")).toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent(/wifi-error\.png was uploaded/);
+  });
+
+  it("reports a server rejection beside the section, naming the file", async () => {
+    mockApi({
+      "GET /api/tickets/42": () => ({ status: 200, body: detail() }),
+      "POST /api/tickets/42/attachments": () =>
+        envelope(415, "ATTACHMENT_TYPE_NOT_ALLOWED", "Attachments must be JPEG, PNG, WEBP or PDF."),
+    });
+    await renderDetail();
+    await screen.findByRole("heading", { name: "Attachments" });
+
+    await userEvent.upload(screen.getByLabelText("Add an attachment"), png("disguised.png"));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/disguised\.png was not uploaded/);
+    expect(alert).toHaveTextContent(/must be JPEG, PNG, WEBP or PDF/);
+    expect(screen.queryByRole("list", { name: "Attachments" })).toBeNull();
+  });
+
+  it("stops offering the control once five attachments are active, and says why", async () => {
+    const five = Array.from({ length: 5 }, (_, index) => ({
+      ...ACTIVE_FILE,
+      id: 100 + index,
+      originalFilename: `shot-${index}.png`,
+    }));
+    mockApi({ "GET /api/tickets/42": () => ({ status: 200, body: detail(five) }) });
+    await renderDetail();
+
+    await screen.findByRole("list", { name: "Attachments" });
+    expect(screen.getByLabelText("Add an attachment")).toBeDisabled();
+    expect(screen.getByText(/already has 5 active attachments/)).toBeInTheDocument();
+  });
+});
+
+describe("Ticket Detail — removal", () => {
+  it("requires a confirmation and a typed reason before it will remove anything", async () => {
+    const { calls } = mockApi({
+      "GET /api/tickets/42": () => ({ status: 200, body: detail([ACTIVE_FILE]) }),
+      "PATCH /api/tickets/42/attachments/7": () => ({
+        status: 200,
+        body: {
+          ...ACTIVE_FILE,
+          removedAt: "2026-08-31T11:00:00.000Z",
+          removedByRequesterId: 1,
+          removalReason: "Contains a colleague's name",
+        },
+      }),
+    });
+    await renderDetail();
+
+    const list = await screen.findByRole("list", { name: "Attachments" });
+    await userEvent.click(within(list).getByRole("button", { name: /^Remove wifi-error\.png$/ }));
+
+    // Nothing has been asked of the server yet: the click opens a confirmation.
+    const dialog = screen.getByRole("alertdialog", { name: "Remove wifi-error.png?" });
+    expect(calls.some((call) => call.method === "PATCH")).toBe(false);
+
+    const confirm = within(dialog).getByRole("button", { name: "Remove attachment" });
+    expect(confirm).toBeDisabled();
+
+    // Four characters is one short of BR-38's minimum, so the button stays shut.
+    await userEvent.type(within(dialog).getByLabelText(/Removal reason/), "oops");
+    expect(confirm).toBeDisabled();
+
+    await userEvent.type(within(dialog).getByLabelText(/Removal reason/), " — contains a colleague's name");
+    expect(confirm).toBeEnabled();
+    await userEvent.click(confirm);
+
+    await waitFor(() => expect(calls.some((call) => call.method === "PATCH")).toBe(true));
+    const patch = calls.find((call) => call.method === "PATCH");
+    expect(JSON.parse(String(patch?.body)).removalReason).toBe("oops — contains a colleague's name");
+
+    // The row stays, now marked and unable to be downloaded (AC-15).
+    const removed = within(await screen.findByRole("list", { name: "Attachments" })).getByRole("listitem");
+    expect(within(removed).getByText("Removed")).toBeInTheDocument();
+    expect(within(removed).getByText(/Contains a colleague's name/)).toBeInTheDocument();
+    expect(within(removed).queryByRole("button", { name: /Download/ })).toBeNull();
+  });
+
+  it("abandons the removal when the confirmation is dismissed", async () => {
+    const { calls } = mockApi({ "GET /api/tickets/42": () => ({ status: 200, body: detail([ACTIVE_FILE]) }) });
+    await renderDetail();
+
+    const list = await screen.findByRole("list", { name: "Attachments" });
+    await userEvent.click(within(list).getByRole("button", { name: /^Remove wifi-error\.png$/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Keep attachment" }));
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(calls.some((call) => call.method === "PATCH")).toBe(false);
+    expect(within(screen.getByRole("list", { name: "Attachments" })).getByText("Active")).toBeInTheDocument();
+  });
+
+  it("puts a server-side reason rejection on the reason field", async () => {
+    mockApi({
+      "GET /api/tickets/42": () => ({ status: 200, body: detail([ACTIVE_FILE]) }),
+      "PATCH /api/tickets/42/attachments/7": () =>
+        envelope(400, "VALIDATION_FAILED", "The attachment could not be removed.", {
+          removalReason: "Give a removal reason of 5-250 characters.",
+        }),
+    });
+    await renderDetail();
+
+    const list = await screen.findByRole("list", { name: "Attachments" });
+    await userEvent.click(within(list).getByRole("button", { name: /^Remove wifi-error\.png$/ }));
+    await userEvent.type(screen.getByLabelText(/Removal reason/), "     spaces only     ");
+    await userEvent.click(screen.getByRole("button", { name: "Remove attachment" }));
+
+    // The message lands on the field it concerns, and the attachment is untouched.
+    const reason = await screen.findByText("Give a removal reason of 5-250 characters.");
+    expect(reason).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -64,6 +64,7 @@ E2E rows below are not claimed runnable until it merges.
 | API-08 | API | AC-10 | Sorting by `requestedPriority` ascending returns `LOW`, `MEDIUM`, `HIGH`, `URGENT` in severity order, not alphabetical order. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-09 | API | AC-09 | An unknown `sortBy`, an unknown `sortOrder`, a `pageSize` outside {10, 25, 50}, a `page` below 1, and an unrecognised priority each return `400` rather than being ignored. | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-10 | API | AC-12 | An owned ticket returns `200`; a ticket owned by another requester returns `404 TICKET_NOT_FOUND`, identical to the response for a nonexistent id. | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
+| API-17 | API | AC-12, AC-15 | Ticket Detail returns full attachment metadata with removed entries present and marked, never the storage key; a non-owner is answered `404` and no filename is disclosed. | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-11 | API | AC-13 | A permitted file under the ceiling returns `201` with active metadata and a stored key that is not derived from the original filename. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-12 | API | AC-14 | Unsupported type returns `415`; oversize returns `413`; a sixth active file returns `409 ATTACHMENT_LIMIT_REACHED`; upload to another requester's ticket returns `404`. No metadata row is written in any case. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-13 | API | AC-15 | Soft removal returns `200` with reason, timestamp and remover; metadata still lists the attachment; a later download returns `404`; a second removal returns `409 ATTACHMENT_ALREADY_REMOVED` without overwriting the first reason. | `server/tests/lab-02/attachments.api.test.ts` | Planned |
@@ -77,8 +78,8 @@ E2E rows below are not claimed runnable until it merges.
 | UI-07 | UI | AC-08 | Changing requester clears filters and paging and reloads the list for the new context. | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-08 | UI | AC-09 | Search, filters, sort and pagination controls drive the request and render the returned metadata, including page and total counts. | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-09 | UI | AC-11 | Owning no tickets and matching no tickets render different messages and different recovery actions. | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-10 | UI | AC-15 | Detail renders every field read-only, shows a removed attachment as retained metadata with a Removed badge, and offers no working download for it. | `client/tests/lab-02/TicketDetail.test.tsx` | Planned |
-| UI-11 | UI | AC-14 | A rejected file is named in the error together with its reason, and other selected files are unaffected. | `client/tests/lab-02/TicketDetail.test.tsx` | Planned |
+| UI-10 | UI | AC-15 | Detail renders every field read-only, shows a removed attachment as retained metadata with a Removed badge, and offers no working download for it. Removal needs a confirmation and a typed reason before anything is sent. | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
+| UI-11 | UI | AC-14 | A rejected file is named in the error together with its reason, and other selected files are unaffected. A server rejection is reported beside the attachment section, naming the file. | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
 | UI-12 | UI | AC-07 | The API client converts a thrown `TypeError: Failed to fetch` into a human message before it reaches a component. | `client/tests/lab-02/apiClient.test.ts` | Planned |
 | STYLE-01 | UI style | AC-16 | Zen Green tokens are applied; required fields carry an asterisk; validation messages render beneath their field; read-only and editable fields are visually distinct; button variants and busy/disabled states are correct; `role="status"` and `role="alert"` are used as specified. | `client/tests/lab-02/ZenGreen.styles.test.tsx` | Planned |
 | RESP-01 | Responsive | AC-16 | Create Ticket, My Tickets and Ticket Detail at 1440×900, 834×1112 and 390×844: no horizontal page scroll, no clipped labels, no overlapping messages. Screenshots are written to `artifacts/lab-02/screenshots/`. | `e2e/lab-02/responsive.spec.ts` | Planned |
@@ -105,10 +106,10 @@ Every acceptance criterion in `specification.md` §9 maps to at least one planne
 | AC-09 Search, filter, sort, page and metadata are correct | UNIT-06, API-07, API-09, UI-08 |
 | AC-10 Priority sorts by severity | API-08 |
 | AC-11 Empty and no-results are distinct | UI-09 |
-| AC-12 Cross-requester access is refused as not found | API-05, API-10, E2E-02 |
+| AC-12 Cross-requester access is refused as not found | API-05, API-10, API-17, E2E-02 |
 | AC-13 Permitted upload and download work | API-11, API-14, E2E-03 |
 | AC-14 Invalid, oversize and excess uploads are refused | UNIT-03, UNIT-04, API-12, UI-11 |
-| AC-15 Soft removal retains metadata and blocks download | UNIT-05, API-13, UI-10, E2E-03 |
+| AC-15 Soft removal retains metadata and blocks download | UNIT-05, API-13, API-17, UI-10, E2E-03 |
 | AC-16 Three viewports render without clipping or overflow | STYLE-01, RESP-01 |
 
 ---
@@ -158,6 +159,41 @@ npx playwright test e2e/lab-02
 unit, API and UI suites captured from `main` after the release merge, together with the
 Playwright run and the responsive screenshots. Test counts and file paths will be filled in
 from that run, not from a feature branch and not from memory.
+
+### Issue #26 feature-branch verification
+
+Run on `feature/26-ticket-detail-and-attachments` on 2026-09-01, before peer review:
+
+- `cd client && npm test` — 8 files, **97 tests passed** (up from 7 files / 84).
+- `cd server && npm test` — 14 files, **126 tests passed** (up from 124).
+- `cd client && npm run build` and `cd server && npm run build` — both passed.
+
+**The detail endpoint was not keeping its own promise.** `api-spec.md` §3 says
+`GET /api/tickets/:ticketId` returns full attachment metadata with removed entries present
+and marked; the handler returned a hard-coded empty array, and the existing API-10 test
+asserted exactly that empty array on a ticket that had no attachments — true, and worth
+nothing. The screen would have shown "no files attached" for every Ticket. API-17 now uploads
+two files, removes one, and asserts both come back with the removal reason on the second and
+no `storageKey` on either. **Verified by breaking the code**: reverting the handler to the
+empty array made API-17 fail with `expected [] to have a length of 2`.
+
+**Three UI claims were proved the same way**, since a test that has never failed proves
+nothing:
+
+- Rendering the Download and Remove actions unconditionally instead of only for active
+  attachments made UI-10 fail on both the removed-metadata case and the after-removal case.
+- Removing the reason-length gate on the destructive confirm button made the removal test
+  fail at `expect(confirm).toBeDisabled()`.
+- The rejected-file test uses `fireEvent`, not `userEvent.upload`, for the same reason
+  `CreateTicket.test.tsx` does: `userEvent` honours the `accept` attribute and would drop
+  `payload.exe` before the component saw it, leaving the client-side type check untested. A
+  browser treats `accept` as a hint, and drag-and-drop ignores it.
+
+**Download goes through `fetch`, not an `<a href>`.** The endpoint is requester-scoped and
+identity travels in `X-Dev-Requester-Id` (D-01); a browser navigation cannot carry a custom
+header, so a plain link would arrive without context and be answered `401`. The bytes are
+fetched with the header and saved through an object URL, which is revoked immediately — the
+test asserts both the header on the request and the revoke.
 
 ### Issue #25 feature-branch verification
 

--- a/server/src/attachment-view.ts
+++ b/server/src/attachment-view.ts
@@ -1,0 +1,22 @@
+import type { Prisma } from "@prisma/client";
+
+/**
+ * The attachment fields any response may carry.
+ *
+ * `storageKey` is deliberately absent: it is an internal locator, and disclosing
+ * it invites someone to ask for it directly (BR-35). The shape lives here rather
+ * than inside a route so the Ticket Detail response and the attachment list
+ * cannot drift apart — api-spec.md §3 says they are the same metadata.
+ */
+export const attachmentSelect = {
+  id: true,
+  originalFilename: true,
+  mimeType: true,
+  sizeBytes: true,
+  uploadedAt: true,
+  removedAt: true,
+  removedByRequesterId: true,
+  removalReason: true,
+} satisfies Prisma.AttachmentSelect;
+
+export type AttachmentView = Prisma.AttachmentGetPayload<{ select: typeof attachmentSelect }>;

--- a/server/src/attachments-route.ts
+++ b/server/src/attachments-route.ts
@@ -2,8 +2,8 @@ import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { Request, Response } from "express";
-import type { Prisma } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
+import { attachmentSelect } from "./attachment-view.js";
 import { sendDependencyUnavailable, sendError } from "./errors.js";
 import { resolveRequester } from "./requester-context.js";
 import { MAX_ACTIVE, checkAttachment, safeDownloadName, validateRemovalReason } from "./attachment-rules.js";
@@ -12,19 +12,6 @@ import { MAX_ACTIVE, checkAttachment, safeDownloadName, validateRemovalReason } 
 // plans worse for no gain (decision D-06). The directory is configurable so the
 // test run and the E2E run do not write into a developer's working copy.
 const storageDirectory = path.resolve(process.env.ATTACHMENT_STORAGE_DIR ?? path.join(process.cwd(), "storage", "attachments"));
-
-// storageKey is never returned: it is an internal locator, and disclosing it
-// invites someone to ask for it directly.
-const attachmentSelect = {
-  id: true,
-  originalFilename: true,
-  mimeType: true,
-  sizeBytes: true,
-  uploadedAt: true,
-  removedAt: true,
-  removedByRequesterId: true,
-  removalReason: true,
-} satisfies Prisma.AttachmentSelect;
 
 type RequesterContext = { id: number; fullName: string };
 

--- a/server/src/tickets-route.ts
+++ b/server/src/tickets-route.ts
@@ -3,6 +3,7 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
 import { sendDependencyUnavailable, sendError } from "./errors.js";
 import { resolveRequester } from "./requester-context.js";
+import { attachmentSelect, type AttachmentView } from "./attachment-view.js";
 import {
   DEFAULT_PAGE_SIZE,
   totalPages as pageCount,
@@ -37,7 +38,12 @@ const ticketSelect = {
 
 type TicketRow = Prisma.TicketGetPayload<{ select: typeof ticketSelect }>;
 
-function serialize(ticket: TicketRow) {
+/**
+ * `attachments` defaults to empty because a Ticket has none at the moment it is
+ * created — the create response in api-spec.md §3 shows exactly that. Ticket
+ * Detail passes the real rows, removed ones included (BR-39).
+ */
+function serialize(ticket: TicketRow, attachments: AttachmentView[] = []) {
   return {
     id: ticket.id,
     ticketNumber: ticket.ticketNumber,
@@ -52,7 +58,7 @@ function serialize(ticket: TicketRow) {
     description: ticket.description,
     requestedPriority: ticket.requestedPriority,
     currentStatus: ticket.currentStatus,
-    attachments: [] as unknown[],
+    attachments,
     createdAt: ticket.createdAt,
     updatedAt: ticket.updatedAt,
   };
@@ -353,7 +359,16 @@ export async function getTicket(req: Request, res: Response): Promise<void> {
       return;
     }
 
-    res.status(200).json(serialize(ticket));
+    // Read only after ownership is established, and only for this ticket, so the
+    // detail response cannot become a way to enumerate someone else's files.
+    // Removed rows are included: BR-39 keeps them visible as marked metadata.
+    const attachments = await getPrisma().attachment.findMany({
+      where: { ticketId: ticket.id },
+      orderBy: { uploadedAt: "asc" },
+      select: attachmentSelect,
+    });
+
+    res.status(200).json(serialize(ticket, attachments));
   } catch (error) {
     sendDependencyUnavailable(res, "GET /api/tickets/:id", error);
   }

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -13,6 +13,32 @@ let ownerId = 0;
 let otherId = 0;
 let ownedTicketId = 0;
 
+// Explicit bytes rather than a string literal: an escape that survives into the
+// file as a real control character makes git treat the whole source as binary.
+const PNG = Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), Buffer.alloc(64, 7)]);
+
+/** A fresh owned ticket, so one test's attachments cannot colour another's. */
+async function newDetailTicket(summary: string): Promise<number> {
+  const [category, relatedSystem] = await Promise.all([
+    prisma.category.findFirstOrThrow({ where: { isActive: true } }),
+    prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true } }),
+  ]);
+
+  const res = await request(app)
+    .post("/api/tickets")
+    .set(REQUESTER_HEADER, String(ownerId))
+    .set("Idempotency-Key", randomUUID())
+    .send({
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      summary,
+      description: "Created by the ticket detail suite so there is something to attach to.",
+      requestedPriority: "MEDIUM",
+    });
+  if (res.status !== 201) throw new Error(`ticket setup failed ${res.status}`);
+  return res.body.id as number;
+}
+
 beforeAll(async () => {
   const [requesters, category, relatedSystem] = await Promise.all([
     prisma.requester.findMany({ where: { isActive: true }, orderBy: { id: "asc" }, take: 2 }),
@@ -80,5 +106,62 @@ describe("GET /api/tickets/:ticketId", () => {
     const res = await request(app).get(`/api/tickets/${ownedTicketId}`);
     expect(res.status).toBe(401);
     expect(res.body.error.code).toBe("REQUESTER_CONTEXT_REQUIRED");
+  });
+});
+
+// The detail response is what Ticket Detail draws its attachment section from
+// (api-spec.md §3). An empty array here would leave the screen with nothing to
+// show for a ticket that does have files, so the promise is worth asserting.
+describe("GET /api/tickets/:ticketId — attachment metadata", () => {
+  it("carries active and removed attachments, and never the storage key", async () => {
+    const ticketId = await newDetailTicket("Detail attachments ticket");
+
+    const kept = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set(REQUESTER_HEADER, String(ownerId))
+      .attach("file", PNG, { filename: "kept.png", contentType: "image/png" });
+    const doomed = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set(REQUESTER_HEADER, String(ownerId))
+      .attach("file", PNG, { filename: "withdrawn.png", contentType: "image/png" });
+    expect([kept.status, doomed.status]).toEqual([201, 201]);
+
+    await request(app)
+      .patch(`/api/tickets/${ticketId}/attachments/${doomed.body.id}`)
+      .set(REQUESTER_HEADER, String(ownerId))
+      .send({ removalReason: "Uploaded the wrong screenshot" });
+
+    const res = await request(app).get(`/api/tickets/${ticketId}`).set(REQUESTER_HEADER, String(ownerId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.attachments).toHaveLength(2);
+
+    const [active, removed] = res.body.attachments as Record<string, unknown>[];
+    expect(active.originalFilename).toBe("kept.png");
+    expect(active.removedAt).toBeNull();
+
+    // BR-39: the removed row keeps its metadata and is marked, rather than
+    // disappearing from the Ticket it belonged to.
+    expect(removed.originalFilename).toBe("withdrawn.png");
+    expect(removed.removedAt).not.toBeNull();
+    expect(removed.removalReason).toBe("Uploaded the wrong screenshot");
+    expect(removed.removedByRequesterId).toBe(ownerId);
+
+    for (const attachment of res.body.attachments as Record<string, unknown>[]) {
+      expect(attachment).not.toHaveProperty("storageKey");
+    }
+  });
+
+  it("does not disclose attachments to a requester who does not own the ticket", async () => {
+    const ticketId = await newDetailTicket("Detail attachments ownership");
+    await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set(REQUESTER_HEADER, String(ownerId))
+      .attach("file", PNG, { filename: "private.png", contentType: "image/png" });
+
+    const res = await request(app).get(`/api/tickets/${ticketId}`).set(REQUESTER_HEADER, String(otherId));
+
+    expect(res.status).toBe(404);
+    expect(JSON.stringify(res.body)).not.toContain("private.png");
   });
 });


### PR DESCRIPTION
Delivers issue #26 — the read-only Ticket Detail screen and the attachment lifecycle in
the interface. Part 8 (View Mode and Attachments).

## What is here

- **Read-only detail** — Ticket Number, Ticket Date, Requester, Category, Related System,
  Summary, Requested Priority, Current Status and Description, all rendered with the
  read-only field treatment. No editable control carries any ticket value.
- **Attachment section** — filename, type, size, upload time and state per file, with
  Download and Remove for active attachments.
- **Removal** — a confirmation naming the file, a typed reason of 5–250 characters, and a
  destructive confirm that stays disabled until the reason is one the server would accept.
- **Removed attachments** — metadata retained, a Removed badge, the reason and date shown,
  and **no download control at all**, with the absence explained in words rather than by
  colour (BR-39).
- **Upload** — one file, checked client-side for type and size before the request, with the
  control disabled and explained once five attachments are active. Errors land beside the
  attachment section and name the file they concern.

## The defect this issue found

`api-spec.md` §3 says `GET /api/tickets/:ticketId` returns full attachment metadata with
removed entries present and marked. The handler returned a hard-coded `attachments: []`, and
API-10 asserted exactly that empty array — on a ticket that had no attachments. True, and
worth nothing. Every Ticket would have shown "no files attached".

`API-17` now uploads two files, removes one, and asserts both come back, that the removed one
carries its reason, remover and timestamp, and that neither carries `storageKey`. Verified by
breaking the code: restoring the empty array fails it with `expected [] to have a length of 2`.

## Download is a fetch, not a link

The endpoint is requester-scoped and identity travels in `X-Dev-Requester-Id` (D-01). A
browser navigation cannot carry a custom header, so an `<a href>` would arrive without context
and be answered `401`. The bytes are fetched with the header and saved through an object URL
that is revoked immediately; the test asserts both the header and the revoke.

## Tests

- `client/tests/lab-02/RequesterTicketDetail.test.tsx` — 13 tests (UI-10, UI-11).
- `server/tests/lab-02/ticket-detail.api.test.ts` — 2 added (API-17).
- `cd client && npm test` — 8 files, **97 passed** (up from 7 / 84).
- `cd server && npm test` — 14 files, **126 passed** (up from 124).
- Both builds pass.

**Three UI claims were proved by breaking the code**, since a test that has never failed
proves nothing: rendering the actions unconditionally fails the removed-metadata assertions;
dropping the reason-length gate fails `expect(confirm).toBeDisabled()`; and the rejected-file
test uses `fireEvent` rather than `userEvent.upload`, because `userEvent` honours `accept` and
would drop `payload.exe` before the component saw it — leaving the client-side check untested.

## What is deliberately not here

Responsive screenshots and the E2E attachment journey belong to #27, which owns Part 3 and
Part 9 evidence. `tests.md` rows stay `Planned` until they run on `main`.
